### PR TITLE
Fixed stale element exception for content page

### DIFF
--- a/pages/content.py
+++ b/pages/content.py
@@ -12,8 +12,8 @@ class Content(Base):
     _title_locator = (By.CSS_SELECTOR, '.media-title h1')
 
     def wait_for_page_to_load(self):
-        self.wait.until(lambda s: self.is_element_displayed(
-            *self._content_locator))
+        self.wait.until(lambda s: self.is_element_present(*self._content_locator))
+        self.wait.until(lambda s: self.is_element_present(*self._title_locator))
         return self
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,5 @@ import pytest
 
 @pytest.fixture
 def selenium(selenium):
-    selenium.implicitly_wait(20)
+    selenium.implicitly_wait(0)
     return selenium

--- a/tests/test_cnx_home.py
+++ b/tests/test_cnx_home.py
@@ -10,8 +10,13 @@ from pages.home import Home
 @pytest.mark.nondestructive
 def test_splash_banner_loads(base_url, selenium):
     page = Home(selenium, base_url).open()
-    assert page.header.is_nav_displayed
     assert 'Discover learning materials in an Open Space' in page.splash
+
+
+@pytest.mark.nondestructive
+def test_nav_is_displayed(base_url, selenium):
+    page = Home(selenium, base_url).open()
+    assert page.header.is_nav_displayed
 
 
 @pytest.mark.nondestructive


### PR DESCRIPTION
* added an additional wait for the title of the content
* broke up the splash text and nav bar check into two tests
* changed the implicit wait to 0 on the selenium fixture