### PR TITLE
Added html report to setup.cfg for pytest and chrome headless cli option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ venv.bak/
 
 # JetBrains
 .idea/
+
+# test report
+/report.html
+/assets/

--- a/pages/home.py
+++ b/pages/home.py
@@ -14,8 +14,8 @@ class Home(Base):
     _featured_books_locator = (By.ID, 'featured-books')
 
     def wait_for_page_to_load(self):
-        self.wait.until(lambda s: self.is_element_displayed(
-            *self._openstax_books_locator))
+        self.wait.until(
+            lambda s: self.find_elements(*self.featured_books._openstax_books_locator))
         return self
 
     @property

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts=--driver=Chrome
+addopts=-vs --driver=Chrome --html report.html --headless
 base_url=https://qa.cnx.org
 sensitive_url=.*
 xfail_strict=true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,20 @@
 import pytest
 
 
+def pytest_addoption(parser):
+    group = parser.getgroup('selenium', 'selenium')
+    group._addoption('--headless',
+                     action='store_true',
+                     help='enable headless mode for chrome.')
+
+
+@pytest.fixture
+def chrome_options(chrome_options, pytestconfig):
+    if pytestconfig.getoption('headless'):
+        chrome_options.add_argument('--headless')
+    return chrome_options
+
+
 @pytest.fixture
 def selenium(selenium):
     selenium.implicitly_wait(0)


### PR DESCRIPTION
* Added the --html report command to setup.cfg in order to generate nice html reports
* Added a command line option --headless to indicate when to run the chrome driver headless.
* Added report files to .gitignore