### PR TITLE
add `--runslow` command line option to allow skipping ncy tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,17 @@ def pytest_addoption(parser):
     group._addoption('--headless',
                      action='store_true',
                      help='enable headless mode for chrome.')
+    parser.addoption("--runslow", action="store_true",
+                     default=False, help="run slow tests")
 
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 @pytest.fixture
 def chrome_options(chrome_options, pytestconfig):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -8,6 +8,7 @@ from pages.content import Content
 
 
 @pytest.mark.nondestructive
+@pytest.mark.slow
 def test_ncy_is_not_displayed(american_gov_url, selenium):
     # GIVEN An American Government URL and Selenium driver
 


### PR DESCRIPTION
Addresses #10.

From the command line:
- `pytest` will skip `test_ncy_is_not_displayed` by default.
- `pytest --runslow` will include `test_ncy_is_not_displayed` (all 80-something tests).


In Pycharm:
- Add `--runslow` to Additional Arguments in your Configurations.