### PR TITLE
Add docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ RUN apt-get update -qqy \
 # Install python
 RUN apt-get update -qqy \
   && apt-get -qqy install \
-    python-pip \
-    python-dev \
+    python3-pip \
+    python3-dev \
     build-essential \
-  && pip install --upgrade pip
+  && pip3 install --upgrade pip
 
 # Install Tox
-RUN pip install tox
+RUN pip3 install tox
 
 WORKDIR /code
 


### PR DESCRIPTION
This will run tox using python 3.5 which is not python 3.6 like we are doing development but it'll be a bit more work to get that fixed and I think it's ok. There isn't much difference in what we are doing between 3.5 and 3.6. The next version of Ubuntu will have Python 3.6 as default. I'm thinking we can roll with it for now. I'll log it as an issue and place a low priority on it. 