### PR TITLE
(Maybe) fix stale element reference errors in webview tests

### DIFF
--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -9,7 +9,7 @@ from pages.webview.base import Base
 
 class Content(Base):
     _content_locator = (By.ID, 'content')
-    _title_locator = (By.CSS_SELECTOR, '.media-title h1')
+    _title_locator = (By.CSS_SELECTOR, 'body .media-title h1')
     _ncy_locator = (By.CLASS_NAME, 'not-converted-yet')
 
     def wait_for_page_to_load(self):

--- a/pages/webview/home.py
+++ b/pages/webview/home.py
@@ -10,7 +10,7 @@ from pages.webview.base import Base
 
 class Home(Base):
     _splash_locator = (By.ID, 'splash')
-    _openstax_books_locator = (By.CSS_SELECTOR, '.featured-books.openstax .books')
+    _openstax_books_locator = (By.CSS_SELECTOR, 'body .featured-books.openstax .books')
     _featured_books_locator = (By.ID, 'featured-books')
 
     def wait_for_page_to_load(self):


### PR DESCRIPTION
This *seems* to work (passed on Travis 3x in a row) but you never know with these intermittent failures. The trick is checking that the elements found via CSS are actually descendants of the body element.