### PR TITLE
Fix webview stale element errors

### DIFF
--- a/pages/webview/base.py
+++ b/pages/webview/base.py
@@ -18,6 +18,8 @@ class Base(Page):
     def body(self):
         return self.find_element(*self._body_locator)
 
+    # Subclasses MUST call super().loaded in their own version of loaded() and
+    # it MUST be called after some other page-specific element's presence is checked
     @property
     def loaded(self):
         return 'Loading...' not in self.body.text

--- a/pages/webview/base.py
+++ b/pages/webview/base.py
@@ -8,9 +8,19 @@ from selenium.webdriver.common.by import By
 
 class Base(Page):
 
+    _body_locator = (By.TAG_NAME, 'body')
+
     @property
     def header(self):
         return self.Header(self)
+
+    @property
+    def body(self):
+        return self.find_element(*self._body_locator)
+
+    @property
+    def loaded(self):
+        return 'Loading...' not in self.body.text
 
     class Header(Region):
 

--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -12,10 +12,11 @@ class Content(Base):
     _title_locator = (By.CSS_SELECTOR, '.media-title h1')
     _ncy_locator = (By.CLASS_NAME, 'not-converted-yet')
 
-    def wait_for_page_to_load(self):
-        self.wait.until(lambda s: self.is_element_present(*self._content_locator))
-        self.wait.until(lambda s: self.is_element_present(*self._title_locator))
-        return self
+    @property
+    def loaded(self):
+        return (self.is_element_present(*self._content_locator) and
+                self.is_element_present(*self._title_locator) and
+                super().loaded)
 
     @property
     def title(self):

--- a/pages/webview/home.py
+++ b/pages/webview/home.py
@@ -13,10 +13,12 @@ class Home(Base):
     _openstax_books_locator = (By.CSS_SELECTOR, '.featured-books.openstax .books')
     _featured_books_locator = (By.ID, 'featured-books')
 
-    def wait_for_page_to_load(self):
-        self.wait.until(
-            lambda s: self.find_elements(*self.featured_books._openstax_books_locator))
-        return self
+    @property
+    def loaded(self):
+        return (self.is_element_present(*self._splash_locator) and
+                self.is_element_present(*self._featured_books_locator) and
+                self.is_element_present(*self.featured_books._openstax_books_locator) and
+                super().loaded)
 
     @property
     def splash(self):


### PR DESCRIPTION
I ran this about 10 times and it passed every time.

Note how `super().loaded` is the last thing I check in each subclass. This actually matters. It was failing with `super().loaded` at the beginning of the condition.