### PR TITLE
Replace --headless option with --headed

### DIFF
--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -15,6 +15,6 @@ def selenium(selenium):
 
 @pytest.fixture
 def chrome_options(chrome_options, pytestconfig):
-    if pytestconfig.getoption('headless'):
+    if not pytestconfig.getoption('headed'):
         chrome_options.add_argument('--headless')
     return chrome_options

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -15,6 +15,6 @@ def selenium(selenium):
 
 @pytest.fixture
 def chrome_options(chrome_options, pytestconfig):
-    if not pytestconfig.getoption('headed'):
+    if not pytestconfig.getoption('--headed'):
         chrome_options.add_argument('--headless')
     return chrome_options

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts=-vs --driver=Chrome --html report.html --headless
+addopts=-vs --driver=Chrome --html report.html
 base_url=https://qa.cnx.org
 legacy_base_url=https://legacy-qa.cnx.org
 sensitive_url=^(?:https?://)?cnx\.org

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def pytest_addoption(parser):
     group = parser.getgroup('selenium', 'selenium')
     group._addoption('--headed',
                      action='store_true',
+                     default=os.getenv('HEADED', False),
                      help='disable headless mode for chrome.')
     parser.addoption('--runslow',
                      action='store_true',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,9 @@ from fixtures.legacy import legacy_base_url, legacy_username, legacy_password
 
 def pytest_addoption(parser):
     group = parser.getgroup('selenium', 'selenium')
-    group._addoption('--headless',
+    group._addoption('--headed',
                      action='store_true',
-                     help='enable headless mode for chrome.')
+                     help='disable headless mode for chrome.')
     parser.addoption('--runslow',
                      action='store_true',
                      default=os.getenv('RUNSLOW', False),

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skipsdist = true
 deps = -rrequirements.txt
 commands = pytest {posargs:tests}
 passenv =
+    HEADED
     RUNSLOW
     LEGACY_BASE_URL
     LEGACY_USERNAME


### PR DESCRIPTION
Since --headless is enabled by default, --headed will deactivate it.

Some random online thesaurus claimed headed was a real adjective and it fits so...