### PR TITLE
Run cnx-automation natively in Travis containers (without Docker)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: 3.6
+cache: pip
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
+python: 3.6
 
-sudo: required
+sudo: false
 
 env:
   global:
@@ -9,18 +10,13 @@ env:
     - MARK=webview
     - MARK=legacy RUNSLOW=true
 
-services:
-  - docker
+addons:
+  apt:
+    packages:
+      - chromium-chromedriver
 
-before_install:
-  - docker info
-
-install:
-  - docker-compose build
-  - docker-compose up -d
+before_script:
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 
 script:
-  - docker-compose exec --user root selenium-chrome tox -- -m $MARK
-
-after_success:
-  - docker-compose down
+  - tox -- -m $MARK

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ sudo: false
 
 env:
   global:
+    - DISABLE_DEV_SHM_USAGE=true
     - HEADLESS=true
+    - NO_SANDBOX=true
   matrix:
     - MARK=webview
     - MARK=legacy RUNSLOW=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ language: python
 sudo: required
 
 env:
-  - MARK=webview
-  - MARK=legacy RUNSLOW=true
+  global:
+    - HEADLESS=true
+  matrix:
+    - MARK=webview
+    - MARK=legacy RUNSLOW=true
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ To run against a different base URL, pass in a value for `--base-url`:
 $ tox -- --base-url=https://qa.cnx.org
 ```
 
+To run Chrome in headless mode, pass in `--headless` or set the HEADLESS environment variable:
+
+```bash
+$ tox -- --headless
+```
+
 To run against a different browser, pass in a value for `--driver`:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   selenium-chrome:
     environment:
       - DISPLAY=:0
+      - HEADLESS
       - RUNSLOW
       - LEGACY_BASE_URL
       - LEGACY_USERNAME

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -19,7 +19,9 @@ def chrome_options(chrome_options, pytestconfig):
         chrome_options.headless = True
 
     # Required to run in Travis containers
-    chrome_options.add_argument('--no-sandbox')
-    chrome_options.add_argument('--disable-dev-shm-usage')
+    if pytestconfig.getoption('--no-sandbox'):
+        chrome_options.add_argument('--no-sandbox')
+    if pytestconfig.getoption('--disable-dev-shm-usage'):
+        chrome_options.add_argument('--disable-dev-shm-usage')
 
     return chrome_options

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -17,4 +17,9 @@ def selenium(selenium):
 def chrome_options(chrome_options, pytestconfig):
     if pytestconfig.getoption('--headless'):
         chrome_options.headless = True
+
+    # Required to run in Travis containers
+    chrome_options.add_argument('--no-sandbox')
+    chrome_options.add_argument('--disable-dev-shm-usage')
+
     return chrome_options

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -15,6 +15,6 @@ def selenium(selenium):
 
 @pytest.fixture
 def chrome_options(chrome_options, pytestconfig):
-    if pytestconfig.getoption('headless'):
-        chrome_options.add_argument('--headless')
+    if pytestconfig.getoption('--headless'):
+        chrome_options.headless = True
     return chrome_options

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts=-vs --driver=Chrome --html report.html --headless
+addopts=-vs --driver=Chrome --html report.html
 base_url=https://qa.cnx.org
 legacy_base_url=https://legacy-qa.cnx.org
 sensitive_url=^(?:https?://)?cnx\.org

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,18 @@ from fixtures.legacy import legacy_base_url, legacy_username, legacy_password
 
 def pytest_addoption(parser):
     group = parser.getgroup('selenium', 'selenium')
+    group.addoption('--disable-dev-shm-usage',
+                    action='store_true',
+                    default=os.getenv('DISABLE_DEV_SHM_USAGE', False),
+                    help="disable chrome's usage of /dev/shm.")
     group.addoption('--headless',
                     action='store_true',
                     default=os.getenv('HEADLESS', False),
                     help='enable headless mode for chrome.')
+    group.addoption('--no-sandbox',
+                    action='store_true',
+                    default=os.getenv('NO_SANDBOX', False),
+                    help="disable chrome's sandbox.")
     parser.addoption('--runslow',
                      action='store_true',
                      default=os.getenv('RUNSLOW', False),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,10 @@ from fixtures.legacy import legacy_base_url, legacy_username, legacy_password
 
 def pytest_addoption(parser):
     group = parser.getgroup('selenium', 'selenium')
-    group._addoption('--headless',
-                     action='store_true',
-                     help='enable headless mode for chrome.')
+    group.addoption('--headless',
+                    action='store_true',
+                    default=os.getenv('HEADLESS', False),
+                    help='enable headless mode for chrome.')
     parser.addoption('--runslow',
                      action='store_true',
                      default=os.getenv('RUNSLOW', False),

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,9 @@ skipsdist = true
 deps = -rrequirements.txt
 commands = pytest {posargs:tests}
 passenv =
+    DISABLE_DEV_SHM_USAGE
     HEADLESS
+    NO_SANDBOX
     RUNSLOW
     LEGACY_BASE_URL
     LEGACY_USERNAME

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skipsdist = true
 deps = -rrequirements.txt
 commands = pytest {posargs:tests}
 passenv =
+    HEADLESS
     RUNSLOW
     LEGACY_BASE_URL
     LEGACY_USERNAME


### PR DESCRIPTION
Here it is, as promised.

Pros:
  - Faster builds (less time waiting for Travis to bootup, Docker and the image don't have to be installed, pip packages can be cached so they don't have to be downloaded every time)

Cons:
  - Travis no longer tests the Docker config

You can decide whether or not this tradeoff is worth it :)

This PR is based on the `headless` PR to avoid future conflicts and for consistency.