### PR TITLE
Test that deletes all content from automation account's personal workspace

### DIFF
--- a/pages/legacy/base.py
+++ b/pages/legacy/base.py
@@ -8,12 +8,16 @@ from selenium.webdriver.common.by import By
 
 
 class Page(pypom.Page):
-    _region_content_locator = (By.ID, 'region-content')
+    _site_error_header_locator = (By.XPATH, ".//h1[text()='Site error']|.//h2[text()='Site Error']")
     _my_account_locator = (By.CSS_SELECTOR, '#portlet-login, #portlet-loggedin')
 
     # Default to a 60 second timeout for CNX legacy
     def __init__(self, driver, base_url=None, timeout=60, **url_kwargs):
         super().__init__(driver, base_url, timeout, **url_kwargs)
+
+    @property
+    def has_site_error(self):
+        return self.is_element_displayed(*self._site_error_header_locator)
 
     @property
     def my_account(self):

--- a/pages/legacy/confirm_publish.py
+++ b/pages/legacy/confirm_publish.py
@@ -14,8 +14,18 @@ class ConfirmPublish(PrivatePage):
     def publish_form(self):
         return self.find_element(*self._publish_form_locator)
 
-    def submit(self):
-        self.publish_form.submit()
+    def submit(self, max_retries=3):
         from pages.legacy.content_published import ContentPublished
         content_published = ContentPublished(self.driver, self.base_url, self.timeout)
-        return content_published.wait_for_page_to_load()
+
+        for i in range(max_retries):
+            self.publish_form.submit()
+            content_published.wait_for_page_to_load()
+
+            if not content_published.has_site_error:
+                break
+
+            self.driver.back()
+            self.wait_for_page_to_load()
+
+        return content_published

--- a/pages/legacy/confirm_publish.py
+++ b/pages/legacy/confirm_publish.py
@@ -18,6 +18,7 @@ class ConfirmPublish(PrivatePage):
         from pages.legacy.content_published import ContentPublished
         content_published = ContentPublished(self.driver, self.base_url, self.timeout)
 
+        # Sometimes publishing fails with a SiteError. In those cases, we retry it a few times.
         for i in range(max_retries):
             self.publish_form.submit()
             content_published.wait_for_page_to_load()

--- a/pages/legacy/confirm_remove.py
+++ b/pages/legacy/confirm_remove.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pages.legacy.base import PrivatePage
+
+from selenium.webdriver.common.by import By
+
+
+class ConfirmRemove(PrivatePage):
+
+    _form_locator = (By.CSS_SELECTOR, 'form[action="folder_delete_confirm"]')
+    _remove_button_locator = (By.CSS_SELECTOR, 'input[type="submit"][name="form.button.delete"]')
+
+    @property
+    def form(self):
+        return self.find_element(*self._form_locator)
+
+    @property
+    def remove_button(self):
+        return self.form.find_element(*self._remove_button_locator)
+
+    def confirm(self):
+        self.remove_button.click()
+        from pages.legacy.workspace import Workspace
+        workspace = Workspace(self.driver, self.base_url, self.timeout)
+        return workspace.wait_for_page_to_load()

--- a/pages/legacy/login_form.py
+++ b/pages/legacy/login_form.py
@@ -35,6 +35,6 @@ class LoginForm(Page):
         self.username_field.send_keys(username)
         self.password_field.send_keys(password)
         self.login_form.submit()
-        from pages.legacy.my_dashboard import MyDashboard
-        my_dashboard = MyDashboard(self.driver, self.base_url, self.timeout)
-        return my_dashboard.wait_for_page_to_load()
+        from pages.legacy.my_cnx import MyCnx
+        my_cnx = MyCnx(self.driver, self.base_url, self.timeout)
+        return my_cnx.wait_for_page_to_load()

--- a/pages/legacy/module_edit.py
+++ b/pages/legacy/module_edit.py
@@ -67,7 +67,7 @@ class ModuleEdit(PrivatePage):
         return ET.tostring(self.content, encoding='unicode')
 
     @property
-    def blank(self):
+    def is_blank(self):
         return self.content_string == self._blank_module_content_string
 
     # When creating a module we sometimes get an error alert

--- a/pages/legacy/my_cnx.py
+++ b/pages/legacy/my_cnx.py
@@ -7,20 +7,31 @@ from pages.legacy.base import PrivatePage
 from selenium.webdriver.common.by import By
 
 
-class MyDashboard(PrivatePage):
-    URL_TEMPLATE = '/mydashboard'
+class MyCnx(PrivatePage):
+    URL_TEMPLATE = '/mycnx'
     _create_a_new_module_locator = (
         By.CSS_SELECTOR, 'p.createlink a[href$="/mydashboard/cc_license?type_name=Module"')
     _create_a_new_collection_locator = (
         By.CSS_SELECTOR, 'p.createlink a[href$="/mydashboard/cc_license?type_name=Collection"')
+    _workspace_link_locator = (By.CSS_SELECTOR, '#cnx_by_location_contents li a')
+
+    @property
+    def create_a_new_collection_link(self):
+        return self.find_element(*self._create_a_new_collection_locator)
 
     @property
     def create_a_new_module_link(self):
         return self.find_element(*self._create_a_new_module_locator)
 
     @property
-    def create_a_new_collection_link(self):
-        return self.find_element(*self._create_a_new_collection_locator)
+    def workspace_link(self):
+        return self.find_element(*self._workspace_link_locator)
+
+    def create_collection(self):
+        self.create_a_new_collection_link.click()
+        from pages.legacy.cc_license import CcLicense
+        cc_license = CcLicense(self.driver, self.base_url, self.timeout)
+        return cc_license.wait_for_page_to_load()
 
     def create_module(self):
         self.create_a_new_module_link.click()
@@ -28,8 +39,8 @@ class MyDashboard(PrivatePage):
         cc_license = CcLicense(self.driver, self.base_url, self.timeout)
         return cc_license.wait_for_page_to_load()
 
-    def create_collection(self):
-        self.create_a_new_collection_link.click()
-        from pages.legacy.cc_license import CcLicense
-        cc_license = CcLicense(self.driver, self.base_url, self.timeout)
-        return cc_license.wait_for_page_to_load()
+    def workspace(self):
+        self.workspace_link.click()
+        from pages.legacy.workspace import Workspace
+        workspace = Workspace(self.driver, self.base_url, self.timeout)
+        return workspace.wait_for_page_to_load()

--- a/pages/legacy/workspace.py
+++ b/pages/legacy/workspace.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pages.legacy.base import PrivatePage
+
+from selenium.webdriver.common.by import By
+
+
+class Workspace(PrivatePage):
+
+    _select_all_checkbox_locator = (By.CSS_SELECTOR, 'input[type="checkbox"][name="selectButton"]')
+    _remove_button_locator = (By.CSS_SELECTOR, 'input[type="submit"][value="Remove"]')
+
+    @property
+    def select_all_checkbox(self):
+        return self.find_element(*self._select_all_checkbox_locator)
+
+    @property
+    def remove_button(self):
+        return self.find_element(*self._remove_button_locator)
+
+    def select_all(self):
+        self.select_all_checkbox.click()
+        return self
+
+    def remove(self):
+        self.remove_button.click()
+        from pages.legacy.confirm_remove import ConfirmRemove
+        confirm_remove = ConfirmRemove(self.driver, self.base_url, self.timeout)
+        return confirm_remove.wait_for_page_to_load()

--- a/regions/legacy/collection.py
+++ b/regions/legacy/collection.py
@@ -13,7 +13,7 @@ class Collection(Content):
     _add_modules_link_locator = (By.CSS_SELECTOR, 'a.action_collection_module')
 
     @property
-    def blank(self):
+    def is_empty(self):
         return not self.is_element_present(*self._content_node_locator)
 
     @property

--- a/regions/legacy/content.py
+++ b/regions/legacy/content.py
@@ -13,7 +13,7 @@ class Content(Region):
 
     def hover(self):
         from selenium.webdriver.common.action_chains import ActionChains
-        ActionChains(self.page.driver).move_to_element(self.root).perform()
+        ActionChains(self.driver).move_to_element(self.root).perform()
         return self
 
     @property

--- a/regions/legacy/my_account.py
+++ b/regions/legacy/my_account.py
@@ -57,9 +57,9 @@ class MyAccount(Region):
         self.username_field.send_keys(username)
         self.password_field.send_keys(password)
         self.login_form.submit()
-        from pages.legacy.my_dashboard import MyDashboard
-        my_dashboard = MyDashboard(self.page.driver, self.page.base_url, self.page.timeout)
-        return my_dashboard.wait_for_page_to_load()
+        from pages.legacy.my_cnx import MyCnx
+        my_cnx = MyCnx(self.page.driver, self.page.base_url, self.page.timeout)
+        return my_cnx.wait_for_page_to_load()
 
     def logout(self):
         self.logout_form.submit()

--- a/regions/legacy/my_account.py
+++ b/regions/legacy/my_account.py
@@ -58,11 +58,11 @@ class MyAccount(Region):
         self.password_field.send_keys(password)
         self.login_form.submit()
         from pages.legacy.my_cnx import MyCnx
-        my_cnx = MyCnx(self.page.driver, self.page.base_url, self.page.timeout)
+        my_cnx = MyCnx(self.driver, self.page.base_url, self.page.timeout)
         return my_cnx.wait_for_page_to_load()
 
     def logout(self):
         self.logout_form.submit()
         from pages.legacy.login_form import LoginForm
-        login_form = LoginForm(self.page.driver, self.page.base_url, self.page.timeout)
+        login_form = LoginForm(self.driver, self.page.base_url, self.page.timeout)
         return login_form.wait_for_page_to_load()

--- a/tests/legacy/ui/test_create_import_publish_remove_module_and_collection.py
+++ b/tests/legacy/ui/test_create_import_publish_remove_module_and_collection.py
@@ -176,9 +176,8 @@ class TestCreateImportPublishRemoveModuleAndCollection(object):
     @markers.slow
     def test_remove_content(self, legacy_base_url, legacy_username, legacy_password, selenium):
         # GIVEN a logged in user on their dashboard with content created in the previous test
-        if ((self.__class__._module_temp_id is None and
-             self.__class__._module_id is None and
-             self.__class__._collection_temp_id is None)):
+        cls = self.__class__
+        if (cls._module_temp_id, cls._module_id, cls._collection_temp_id) == (None, None, None):
             pytest.skip('This test requires CNX content from previous tests that failed')
         login_page = LoginForm(selenium, legacy_base_url).open()
         my_cnx = login_page.login(legacy_username, legacy_password)

--- a/tests/legacy/ui/test_login_logout.py
+++ b/tests/legacy/ui/test_login_logout.py
@@ -5,7 +5,7 @@
 from tests import markers
 
 from pages.legacy.home import Home
-from pages.legacy.my_dashboard import MyDashboard
+from pages.legacy.my_cnx import MyCnx
 from pages.legacy.login_form import LoginForm
 
 
@@ -19,12 +19,11 @@ class TestLoginLogout(object):
         home = Home(selenium, legacy_base_url).open()
 
         # WHEN we login
-        my_dashboard = home.login(legacy_username, legacy_password)
+        my_cnx = home.login(legacy_username, legacy_password)
 
-        # THEN the user is logged in (at their dashboard)
-        # and the correct username is displayed
-        assert type(my_dashboard) is MyDashboard
-        assert my_dashboard.username == legacy_username
+        # THEN the user is logged in (at their dashboard) and the correct username is displayed
+        assert type(my_cnx) is MyCnx
+        assert my_cnx.username == legacy_username
 
     @markers.legacy
     @markers.slow
@@ -34,8 +33,8 @@ class TestLoginLogout(object):
         home = Home(selenium, legacy_base_url).open()
 
         # WHEN we login, then logout
-        my_dashboard = home.login(legacy_username, legacy_password)
-        login_page = my_dashboard.logout()
+        my_cnx = home.login(legacy_username, legacy_password)
+        login_page = my_cnx.logout()
 
         # THEN the user is logged out (at the login form page)
         assert type(login_page) is LoginForm
@@ -48,12 +47,11 @@ class TestLoginLogout(object):
         login_page = LoginForm(selenium, legacy_base_url).open()
 
         # WHEN we login
-        my_dashboard = login_page.login(legacy_username, legacy_password)
+        my_cnx = login_page.login(legacy_username, legacy_password)
 
-        # THEN the user is logged in (at their dashboard)
-        # and the correct username is displayed
-        assert type(my_dashboard) is MyDashboard
-        assert my_dashboard.username == legacy_username
+        # THEN the user is logged in (at their dashboard) and the correct username is displayed
+        assert type(my_cnx) is MyCnx
+        assert my_cnx.username == legacy_username
 
     @markers.legacy
     @markers.slow
@@ -64,8 +62,8 @@ class TestLoginLogout(object):
         login_page = LoginForm(selenium, legacy_base_url).open()
 
         # WHEN we login, then logout
-        my_dashboard = login_page.login(legacy_username, legacy_password)
-        login_page = my_dashboard.logout()
+        my_cnx = login_page.login(legacy_username, legacy_password)
+        login_page = my_cnx.logout()
 
         # THEN the user is logged out (at the login form page)
         assert type(login_page) is LoginForm


### PR DESCRIPTION
Ross said this would be good to prevent the workspace from growing unbounded, potentially causing tests to take longer and longer.

Includes https://github.com/openstax/cnx-automation/pull/60, so probably merge that first, then rebase to master for smaller diff. Or just look at https://github.com/openstax/cnx-automation/pull/64/commits/46fa56826eaa577f08b2fb61edfd663018eda052 and https://github.com/openstax/cnx-automation/pull/64/commits/8f56b016448944ff1105e7ddc12b8935bc15779e for the diff after #60.