### PR TITLE
Added tests for social share links

### DIFF
--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from pypom import Region
+
 from selenium.webdriver.common.by import By
 
 from pages.webview.base import Base
@@ -22,3 +24,61 @@ class Content(Base):
     @property
     def is_ncy_displayed(self):
         return self.is_element_displayed(*self._ncy_locator)
+
+    @property
+    def share(self):
+        return self.Share(self)
+
+    class Share(Region):
+        _root_locator = (By.CSS_SELECTOR, 'div.share')
+
+        @property
+        def current_url(self):
+            return self.driver.current_url
+
+        @property
+        def normalized_title(self):
+            return self.page.title.replace(' ', '%20')
+
+        def _share_link_locator(self, url):
+            return (By.CSS_SELECTOR, 'a[href="{url}"]'.format(url=url))
+
+        @property
+        def _facebook_share_link_locator(self):
+            url = 'https://facebook.com/sharer/sharer.php?u={url}'.format(url=self.current_url)
+            return self._share_link_locator(url)
+
+        @property
+        def _twitter_share_link_locator(self):
+            url = 'https://twitter.com/share?url={url}&text={title}&via=cnxorg'.format(
+                  url=self.current_url, title=self.normalized_title)
+            return self._share_link_locator(url)
+
+        @property
+        def _google_share_link_locator(self):
+            url = 'https://plus.google.com/share?url={url}'.format(url=self.current_url)
+            return self._share_link_locator(url)
+
+        @property
+        def _linkedin_share_link_locator(self):
+            url = (
+                'https://www.linkedin.com/shareArticle?mini=true&url={url}&title={title}&'
+                'summary=An%20OpenStax%20CNX%20book&source=OpenStax%20CNX'
+            ).format(url=self.current_url, title=self.normalized_title)
+            return self._share_link_locator(url)
+
+        @property
+        def is_facebook_share_link_displayed(self):
+            return self.is_element_displayed(*self._facebook_share_link_locator)
+
+        @property
+        def is_twitter_share_link_displayed(self):
+            return self.is_element_displayed(*self._twitter_share_link_locator)
+
+        @property
+        def is_google_share_link_displayed(self):
+            return self.is_element_displayed(*self._google_share_link_locator)
+
+        @property
+        def is_linkedin_share_link_displayed(self):
+            return self.is_element_displayed(*self._linkedin_share_link_locator)

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -4,7 +4,44 @@
 
 from tests import markers
 
+from pages.webview.home import Home
 from pages.webview.content import Content
+
+
+@markers.webview
+@markers.nondestructive
+def test_share_on_top_right_corner(base_url, selenium):
+    # GIVEN the home page
+    home = Home(selenium, base_url).open()
+
+    # WHEN a book is clicked
+    book = home.featured_books.openstax_list[0]
+    content = book.click_book_cover()
+
+    # THEN social share links are displayed in the top right corner
+    root = content.share.root
+    # Top half
+    assert root.location['y'] + root.size['height'] < selenium.get_window_size()['height']/2
+    # Right half
+    assert root.location['x'] > selenium.get_window_size()['width']/2
+
+
+@markers.webview
+@markers.nondestructive
+def test_share_links_displayed(base_url, selenium):
+    # GIVEN the home page
+    home = Home(selenium, base_url).open()
+
+    # WHEN a book is clicked
+    book = home.featured_books.openstax_list[0]
+    content = book.click_book_cover()
+
+    # THEN social share links are displayed with the expected urls
+    share = content.share
+    assert share.is_facebook_share_link_displayed
+    assert share.is_twitter_share_link_displayed
+    assert share.is_google_share_link_displayed
+    assert share.is_linkedin_share_link_displayed
 
 
 @markers.webview


### PR DESCRIPTION
https://github.com/openstax/cnx-automation/issues/53
https://github.com/openstax/cnx-automation/issues/54
https://github.com/openstax/cnx-automation/issues/55
https://github.com/openstax/cnx-automation/issues/56

These tests do not actually click the links, they only test the link urls match a template.