### PR TITLE
Remove legacy login-only tests

### DIFF
--- a/tests/legacy/ui/test_login_logout.py
+++ b/tests/legacy/ui/test_login_logout.py
@@ -14,44 +14,21 @@ class TestLoginLogout(object):
     @markers.legacy
     @markers.slow
     @markers.nondestructive
-    def test_home_login(self, legacy_base_url, legacy_username, legacy_password, selenium):
-        # GIVEN the legacy homepage
-        home = Home(selenium, legacy_base_url).open()
-
-        # WHEN we login
-        my_cnx = home.login(legacy_username, legacy_password)
-
-        # THEN the user is logged in (at their dashboard) and the correct username is displayed
-        assert type(my_cnx) is MyCnx
-        assert my_cnx.username == legacy_username
-
-    @markers.legacy
-    @markers.slow
-    @markers.nondestructive
     def test_home_login_logout(self, legacy_base_url, legacy_username, legacy_password, selenium):
         # GIVEN the legacy homepage
         home = Home(selenium, legacy_base_url).open()
 
         # WHEN we login, then logout
         my_cnx = home.login(legacy_username, legacy_password)
+
+        # The user is logged in (at their dashboard) and the correct username is displayed
+        assert type(my_cnx) is MyCnx
+        assert my_cnx.username == legacy_username
+
         login_page = my_cnx.logout()
 
         # THEN the user is logged out (at the login form page)
         assert type(login_page) is LoginForm
-
-    @markers.legacy
-    @markers.slow
-    @markers.nondestructive
-    def test_login_page_login(self, legacy_base_url, legacy_username, legacy_password, selenium):
-        # GIVEN the legacy login form page
-        login_page = LoginForm(selenium, legacy_base_url).open()
-
-        # WHEN we login
-        my_cnx = login_page.login(legacy_username, legacy_password)
-
-        # THEN the user is logged in (at their dashboard) and the correct username is displayed
-        assert type(my_cnx) is MyCnx
-        assert my_cnx.username == legacy_username
 
     @markers.legacy
     @markers.slow
@@ -63,6 +40,11 @@ class TestLoginLogout(object):
 
         # WHEN we login, then logout
         my_cnx = login_page.login(legacy_username, legacy_password)
+
+        # The user is logged in (at their dashboard) and the correct username is displayed
+        assert type(my_cnx) is MyCnx
+        assert my_cnx.username == legacy_username
+
         login_page = my_cnx.logout()
 
         # THEN the user is logged out (at the login form page)


### PR DESCRIPTION
Literally every single other test also logs in, so no point in testing login by itself.
Less legacy tests also means a faster test suite since legacy is so slow.
Moved some of the assertions of these tests to the login/logout tests, which are still there (git thinks I renamed the tests but really I deleted them and moved the assertions).