### PR TITLE
Import fixture refactor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ import pytest
 
 from dotenv import load_dotenv
 
+# Patch remote_connection to workaround Connection Reset by Peer bug in the Selenium driver
+# https://github.com/SeleniumHQ/selenium/issues/5296
+from patches import connection_reset_by_peer # noqa: F401
+
 # Import fixtures
 pytest_plugins = (
     'fixtures.base',
@@ -15,10 +19,6 @@ pytest_plugins = (
     'fixtures.webview',
     'fixtures.legacy',
 )
-
-# Patch remote_connection to workaround Connection Reset by Peer bug in the Selenium driver
-# https://github.com/SeleniumHQ/selenium/issues/5296
-from patches import connection_reset_by_peer
 
 # Load environment variables from .env file
 DOTENV_PATH = os.path.join(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,14 @@ import pytest
 
 from dotenv import load_dotenv
 
-# Import fixtures from our package so pytest can detect them
-from fixtures.base import chrome_options, selenium # flake8: noqa
-from fixtures.snapshot import snapshot
-from fixtures.archive import archive_base_url
-from fixtures.webview import american_gov_url, content_url
-from fixtures.legacy import (legacy_base_url, legacy_username, legacy_password,
-                             m46922_1_13_cnxml_filepath)
+# Import fixtures
+pytest_plugins = (
+    'fixtures.base',
+    'fixtures.snapshot',
+    'fixtures.archive',
+    'fixtures.webview',
+    'fixtures.legacy',
+)
 
 # Patch remote_connection to workaround Connection Reset by Peer bug in the Selenium driver
 # https://github.com/SeleniumHQ/selenium/issues/5296

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 # Patch remote_connection to workaround Connection Reset by Peer bug in the Selenium driver
 # https://github.com/SeleniumHQ/selenium/issues/5296
-from patches import connection_reset_by_peer # noqa: F401
+from patches import connection_reset_by_peer  # noqa: F401
 
 # Import fixtures
 pytest_plugins = (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 # Patch remote_connection to workaround Connection Reset by Peer bug in the Selenium driver
 # https://github.com/SeleniumHQ/selenium/issues/5296
-from patches import connection_reset_by_peer  # noqa: F401
+from patches import connection_reset_by_peer  # noqa
 
 # Import fixtures
 pytest_plugins = (


### PR DESCRIPTION
changes the way we import fixtures. this sets us up nicely to also import any plugins we decide to create within the project later down the road. I plan on creating a couple first within this repo and then splitting them out later when necessary. 