### PR TITLE
Don't print head tag when printing page source

### DIFF
--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -4,6 +4,9 @@
 
 import pytest
 
+from lxml import etree
+from lxml.etree import XMLSyntaxError
+
 __all__ = ['selenium', 'chrome_options']
 
 
@@ -18,7 +21,18 @@ def selenium(request, selenium, pytestconfig):
        request.node.rep_call.failed:
         # print page source on failure
         print('\n------------------------------ Begin Page Source -------------------------------')
-        print(selenium.page_source)
+        source = selenium.page_source
+        try:
+            html = etree.fromstring(source)
+        except XMLSyntaxError:
+            # If we can't parse the page source as XML, then just print the entire thing
+            print(source)
+        else:
+            # Remove head tag and pretty print
+            head = html.find('{http://www.w3.org/1999/xhtml}head')
+            if head:
+                html.remove(head)
+            print(etree.tostring(html, encoding='unicode', pretty_print=True))
         print('------------------------------- End Page Source --------------------------------')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ attrs==18.1.0
 certifi==2018.4.16
 chardet==3.0.4
 idna==2.7
+lxml==4.2.1
 more-itertools==4.2.0
 pluggy==0.6.0
 py==1.5.3


### PR DESCRIPTION
Using the lxml library was the easiest way I found to pretty print (and print the tags without the namespaces).