### PR TITLE
Fix deprecation warning

### DIFF
--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -30,7 +30,7 @@ def selenium(request, selenium, pytestconfig):
         else:
             # Remove head tag and pretty print
             head = html.find('{http://www.w3.org/1999/xhtml}head')
-            if head:
+            if head is not None:
                 html.remove(head)
             print(etree.tostring(html, encoding='unicode', pretty_print=True))
         print('------------------------------- End Page Source --------------------------------')


### PR DESCRIPTION
```
=============================== warnings summary ===============================
tests/webview/ui/test_about.py::test_about_us_content_includes_openstax_goals
  /home/travis/build/openstax/cnx-automation/fixtures/base.py:33: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    if head:
tests/webview/ui/test_about.py::test_about_us_content_links
  /home/travis/build/openstax/cnx-automation/fixtures/base.py:33: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    if head:
tests/webview/ui/test_content.py::test_share_on_top_right_corner
  /home/travis/build/openstax/cnx-automation/fixtures/base.py:33: FutureWarning: The behavior of this method will change in future versions. Use specific 'len(elem)' or 'elem is not None' test instead.
    if head:
-- Docs: http://doc.pytest.org/en/latest/warnings.html
```

Background: https://stackoverflow.com/questions/20129996/why-does-boolxml-etree-elementtree-element-evaluate-to-false