### PR TITLE
Retry legacy SiteError when creating module

### DIFF
--- a/pages/legacy/confirm_publish.py
+++ b/pages/legacy/confirm_publish.py
@@ -16,20 +16,20 @@ class ConfirmPublish(PrivatePage):
     def publish_form(self):
         return self.find_element(*self._publish_form_locator)
 
-    def submit(self, max_tries=3):
+    def submit(self, max_attempts=3):
         from pages.legacy.content_published import ContentPublished
         content_published = ContentPublished(self.driver, self.base_url, self.timeout)
 
         # Sometimes publishing fails with a SiteError. In those cases, we retry it a few times.
-        for i in range(max_tries):
+        for i in range(max_attempts):
             self.publish_form.submit()
-            content_published.wait_for_page_to_load()
+            content_published = content_published.wait_for_page_to_load()
 
             if not content_published.has_site_error:
                 break
-            elif i >= max_tries - 1:
-                pytest.fail('Maximum number of tries exceeded for SiteError'
-                            ' ({tries})'.format(tries=max_tries))
+            elif i >= max_attempts - 1:
+                pytest.fail('Maximum number of attempts exceeded for SiteError'
+                            ' ({attempts})'.format(attempts=max_attempts))
 
             self.driver.back()
             self.wait_for_page_to_load()

--- a/pages/legacy/metadata_edit.py
+++ b/pages/legacy/metadata_edit.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import pytest
+
 from pages.legacy.base import PrivatePage
 
 from selenium.webdriver.common.by import By
@@ -38,18 +40,29 @@ class MetadataEdit(PrivatePage):
         self.title_field.send_keys(title)
         return self
 
-    def submit(self):
-        is_collection = self.is_collection
-
-        # Unlike the other forms, we actually have to click the submit button here
-        # when creating the module, otherwise we end up in the wrong page (metadata edit page)
-        self.submit_button.click()
-
-        if is_collection:
+    def submit(self, max_attempts=3):
+        if self.is_collection:
             from pages.legacy.collection_edit import CollectionEdit
             edit = CollectionEdit(self.driver, self.base_url, self.timeout)
         else:
             from pages.legacy.module_edit import ModuleEdit
             edit = ModuleEdit(self.driver, self.base_url, self.timeout)
 
-        return edit.wait_for_page_to_load()
+        # Sometimes creating a module fails with a SiteError.
+        # In those cases, we retry it a few times.
+        for i in range(max_attempts):
+            # Unlike the other forms, we actually have to click the submit button here
+            # when creating the module, otherwise we end up in the wrong page (metadata edit page)
+            self.submit_button.click()
+            edit = edit.wait_for_page_to_load()
+
+            if not edit.has_site_error:
+                break
+            elif i >= max_attempts - 1:
+                pytest.fail('Maximum number of attempts exceeded for SiteError'
+                            ' ({attempts})'.format(attempts=max_attempts))
+
+            self.driver.back()
+            self.wait_for_page_to_load()
+
+        return edit

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,21 +27,21 @@ def patch_module(source_module_name, target_module_name, attr):
 
 # Retries StaleElementReferenceExceptions up to n-1 times (default n=3)
 # Decorator with optional argument based on: https://stackoverflow.com/a/3931903
-def retry_stale_element_reference_exception(method_or_max_tries):
+def retry_stale_element_reference_exception(method_or_max_attempts):
     def wrap(method):
         @wraps(method)
         def wrapper(*args, **kwargs):
-            for i in range(max_tries):
+            for i in range(max_attempts):
                 try:
                     return method(*args, **kwargs)
                 except StaleElementReferenceException:
-                    if i >= max_tries - 1:
+                    if i >= max_attempts - 1:
                         raise
         return wrapper
 
-    if callable(method_or_max_tries):
-        max_tries = 3
-        return wrap(method_or_max_tries)
+    if callable(method_or_max_attempts):
+        max_attempts = 3
+        return wrap(method_or_max_attempts)
     else:
-        max_tries = method_or_max_tries
+        max_attempts = method_or_max_attempts
         return wrap


### PR DESCRIPTION
Fixes a sporadic failure in the legacy tests.

Also renamed max_tries to max_attempts.