### PR TITLE
Changed the html report to be standalone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ clean-pyc: ## remove Python file artifacts
 clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/
 	rm -fr assets/
+	rm -f report.html
 
 venv:
 	python3 -m venv .venv && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts=-vs --driver=Chrome --html report.html
+addopts=-vs --driver=Chrome --html report.html --self-contained-html
 archive_base_url=https://archive-qa.cnx.org
 legacy_base_url=https://legacy-qa.cnx.org
 webview_base_url=https://staging.cnx.org


### PR DESCRIPTION
A tool will be used to upload the report and this is made easier by
using the standalone report as it will base64 encode the logs and
images.

* Added `--self-contained` to setup.cfg pytest addopts
* Updated Makefile to remove report.html when `make clean` command is
used