### PR TITLE
Add test case C162195 to test_id_links_and_back_button

### DIFF
--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -343,7 +343,7 @@ def test_ncy_is_not_displayed(american_gov_url, selenium):
 
 
 @markers.webview
-@markers.test_case('C132547', 'C132548')
+@markers.test_case('C132547', 'C132548', 'C162195')
 @markers.nondestructive
 @markers.parametrize(
     'page_uuid,is_baked_book_index',


### PR DESCRIPTION
https://github.com/openstax/cnx-automation/issues/153

(The test already asserts this by checking that the elements are displayed after clicking the links)