### PR TITLE
Made the NCY tests work with the URL_TEMPLATE in the Content page class

### DIFF
--- a/fixtures/webview.py
+++ b/fixtures/webview.py
@@ -9,25 +9,16 @@ from tests.utils import gen_from_file, skip_if_destructive_and_sensitive
 
 DATA_DIR = os.path.join(os.path.realpath(os.path.dirname(__file__)), 'data', 'webview')
 
-__all__ = ['content_url', 'american_gov_url', 'webview_base_url']
-
-
-@pytest.fixture
-def content_url(base_url):
-    """Creates contents URL based on the base_url
-
-    Example: https://qa.cnx.org/contents
-    """
-    return '{0}/{1}'.format(base_url, 'contents')
+__all__ = ['american_gov_uuid', 'webview_base_url']
 
 
 @pytest.fixture(params=gen_from_file(os.path.join(DATA_DIR, 'american_gov_uuids.txt')))
-def american_gov_url(content_url, request):
-    """Creates an American Government URL based on the content_url fixture and a UUID
+def american_gov_uuid(request):
+    """Yields American Government UUIDs from the american_gov_uuids.txt file
 
-    Example: https://qa.cnx.org/contents/c6ee95dd-d10b-430c-8a83-20d5a28334a9
+    Example: c6ee95dd-d10b-430c-8a83-20d5a28334a9
     """
-    yield '{0}/{1}'.format(content_url, request.param)
+    yield request.param
 
 
 @pytest.fixture

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -399,11 +399,11 @@ def test_navigation(webview_base_url, selenium):
 @markers.test_case('C195073')
 @markers.slow
 @markers.nondestructive
-def test_ncy_is_not_displayed(american_gov_url, selenium):
-    # GIVEN An American Government URL and Selenium driver
+def test_ncy_is_not_displayed(webview_base_url, american_gov_uuid, selenium):
+    # GIVEN the webview base url, an American Government content page UUID, and the Selenium driver
 
-    # WHEN The page is fully loaded using the URL
-    page = Content(selenium, american_gov_url).open()
+    # WHEN the page is fully loaded using the URL
+    page = Content(selenium, webview_base_url, id=american_gov_uuid).open()
 
     # THEN :NOT_CONVERTED_YET is not displayed
     assert page.is_ncy_displayed is False


### PR DESCRIPTION
The content_url fixture is no longer needed because the `Content` class takes care of it now.