### PR TITLE
Added Neb to the Travis build matrix and updated it to 5.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   matrix:
     - MARK=webview
     - MARK=legacy RUNSLOW=true
+    - MARK=neb
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ before_script:
   - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 
 script:
-  - tox -- -m $MARK
+  - tox -- -m $MARK -vv

--- a/fixtures/snapshot.py
+++ b/fixtures/snapshot.py
@@ -45,9 +45,10 @@ class Snapshot(object):
         snapshot_path = self.get_snapshot_path_and_ensure_dir_exists('tar_gz', name)
 
         if os.path.isfile(snapshot_path):
-            with tarfile.open(snapshot_path, 'r|gz') as snapshot_tar:
+            with tarfile.open(snapshot_path, 'r|gz', encoding='utf-8') as snapshot_tar:
                 for snapshot_tarinfo in snapshot_tar:
-                    subpath = os.path.join(path, snapshot_tarinfo.name)
+                    name = snapshot_tarinfo.name
+                    subpath = os.path.join(path, name)
 
                     if snapshot_tarinfo.isdir():
                         assert os.path.isdir(subpath)
@@ -57,9 +58,9 @@ class Snapshot(object):
                         with open(subpath, 'rb') as file:
                             value = file.read()
                         assert value == snapshot_value, (
-                            '{path} failed to match against the snapshot.'.format(path=subpath))
+                            '{name} did not match the snapshot.'.format(name=name))
         else:
-            with tarfile.open(snapshot_path, 'w|gz') as snapshot_tar:
+            with tarfile.open(snapshot_path, 'w|gz', encoding='utf-8') as snapshot_tar:
                 # arcname='.' makes tar not save the absolute path
                 # See comments in https://stackoverflow.com/a/2239679
                 snapshot_tar.add(path, arcname='.')

--- a/fixtures/snapshot.py
+++ b/fixtures/snapshot.py
@@ -56,7 +56,8 @@ class Snapshot(object):
                             snapshot_value = snapshot_file.read()
                         with open(subpath, 'rb') as file:
                             value = file.read()
-                        assert value == snapshot_value
+                        assert value == snapshot_value, (
+                            '{path} failed to match against the snapshot.'.format(path=subpath))
         else:
             with tarfile.open(snapshot_path, 'w|gz') as snapshot_tar:
                 # arcname='.' makes tar not save the absolute path

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ github3.py==1.1.0
 idna==2.7
 lxml==4.2.2
 more-itertools==4.2.0
-nebuchadnezzar==4.0.0
+nebuchadnezzar==5.0.0
 pluggy==0.6.0
 py==1.5.3
 PyPOM==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ github3.py==1.1.0
 idna==2.7
 lxml==4.2.2
 more-itertools==4.2.0
-nebuchadnezzar==5.0.0
+nebuchadnezzar==5.0.1
 pluggy==0.6.0
 py==1.5.3
 PyPOM==2.0.0


### PR DESCRIPTION
Only neb usage and get tests exist for now.

We should do this before upgrading to Neb 5.0.0 to ensure the tests still work for the latest version.

See also: https://github.com/openstax/cnx-automation/pull/196