### PR TITLE
Make some tests that were failing locally less flaky

### DIFF
--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -7,7 +7,17 @@ import pytest
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 
-__all__ = ['language', 'selenium', 'chrome_options']
+__all__ = ['width', 'height', 'language', 'selenium', 'chrome_options']
+
+
+@pytest.fixture
+def width(request):
+    return 1024
+
+
+@pytest.fixture
+def height(request):
+    return 768
 
 
 @pytest.fixture
@@ -17,8 +27,8 @@ def language(request):
 
 # https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 @pytest.fixture
-def selenium(request, selenium, pytestconfig):
-    selenium.implicitly_wait(0)
+def selenium(selenium, pytestconfig, width, height, request):
+    selenium.set_window_size(width, height)
     yield selenium
     # request.node is an "item" because we use the default "function" scope
     if pytestconfig.getoption('--print-page-source-on-failure') and \
@@ -44,7 +54,7 @@ def selenium(request, selenium, pytestconfig):
 
 
 @pytest.fixture
-def chrome_options(chrome_options, language, pytestconfig):
+def chrome_options(chrome_options, pytestconfig, language):
     if pytestconfig.getoption('--headless'):
         chrome_options.headless = True
 

--- a/pages/webview/base.py
+++ b/pages/webview/base.py
@@ -4,7 +4,6 @@
 
 import pypom
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.action_chains import ActionChains
 
 from regions.webview.base import Region
 
@@ -24,18 +23,31 @@ class Page(pypom.Page):
     def footer(self):
         return self.Footer(self)
 
-    def scroll_to(self, element):
-        """Scrolls to the given element. Returns the page."""
-        ActionChains(self.driver).move_to_element(element).perform()
+    def wait_for_region_to_display(self, region):
+        self.wait.until(lambda _: region.is_displayed)
         return self
 
+    def wait_for_element_to_display(self, element):
+        self.wait.until(lambda _: element.is_displayed())
+        return self
+
+    def scroll_to(self, element=None):
+        """Scrolls to the given element. Returns the element."""
+        from selenium.webdriver.common.action_chains import ActionChains
+        ActionChains(self.driver).move_to_element(element).perform()
+        return element
+
     def offscreen_click(self, element):
-        """Clicks the given element, even if it is offscreen. Returns the page."""
+        """Clicks an offscreen element.
+
+        Clicks the given element, even if it is offscreen, by sending the ENTER key.
+        Returns the element.
+        """
         # We actually navigate using the ENTER key because scrolling the page can be flaky
         # https://stackoverflow.com/a/39918249
         from selenium.webdriver.common.keys import Keys
         element.send_keys(Keys.ENTER)
-        return self
+        return element
 
     class Header(Region):
         _root_locator = (By.CSS_SELECTOR, 'header#header div.page-header')
@@ -135,11 +147,14 @@ class Page(pypom.Page):
             return self.donate_link.get_attribute('href')
 
         @property
+        def are_nav_links_displayed(self):
+            return (self.is_browse_link_displayed and
+                    self.is_about_us_link_displayed and
+                    self.is_donate_link_displayed)
+
+        @property
         def is_nav_displayed(self):
-            return (self.is_nav_button_displayed or
-                    (self.is_browse_link_displayed and
-                     self.is_about_us_link_displayed and
-                     self.is_donate_link_displayed))
+            return self.is_nav_button_displayed or self.are_nav_links_displayed
 
         @property
         def rice_logo(self):
@@ -160,10 +175,18 @@ class Page(pypom.Page):
                     self.is_cnx_logo_displayed and
                     self.is_nav_displayed)
 
+        def wait_for_nav_links_to_display(self):
+            self.wait.until(lambda _: self.are_nav_links_displayed)
+            return self
+
         def click_cnx_logo(self):
             self.cnx_logo.click()
             from pages.webview.home import Home
             return Home(self.driver, self.page.base_url, self.page.timeout).wait_for_page_to_load()
+
+        def click_nav_button(self):
+            self.nav_button.click()
+            return self.wait_for_nav_links_to_display()
 
         def click_search(self):
             self.find_element(*self._browse_link_locator).click()

--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -600,14 +600,14 @@ class Content(Page):
 
             def click_back_link(self):
                 current_url = self.driver.current_url
-                self.scroll_to().back_link.click()
+                self.offscreen_click(self.back_link)
                 return self.page.wait_for_url_to_change(current_url)
 
             def click_back_to_top_link(self):
-                self.back_to_top_link.click()
+                self.offscreen_click(self.back_to_top_link)
                 return self.page.wait_for_page_to_load()
 
             def click_next_link(self):
                 current_url = self.driver.current_url
-                self.scroll_to().next_link.click()
+                self.offscreen_click(self.next_link)
                 return self.page.wait_for_url_to_change(current_url)

--- a/pages/webview/home.py
+++ b/pages/webview/home.py
@@ -56,19 +56,19 @@ class Home(Page):
             return self.find_element(*self._book_intro_locator).text
 
         def click_read_more(self):
-            self.scroll_to().find_element(*self._read_more_locator).click()
+            self.offscreen_click(self.find_element(*self._read_more_locator))
             from pages.webview.content import Content
             content = Content(self.driver, self.page.base_url, self.page.timeout)
             return content.wait_for_page_to_load()
 
         def click_book_cover(self):
-            self.scroll_to().find_element(*self._book_cover_link_locator).click()
+            self.offscreen_click(self.find_element(*self._book_cover_link_locator))
             from pages.webview.content import Content
             content = Content(self.driver, self.page.base_url, self.page.timeout)
             return content.wait_for_page_to_load()
 
         def click_title_link(self):
-            self.scroll_to().find_element(*self._title_link_locator).click()
+            self.offscreen_click(self.find_element(*self._title_link_locator))
             from pages.webview.content import Content
             content = Content(self.driver, self.page.base_url, self.page.timeout)
             return content.wait_for_page_to_load()

--- a/regions/webview/base.py
+++ b/regions/webview/base.py
@@ -24,25 +24,27 @@ class Region(pypom.Region):
 
     @property
     def is_displayed(self):
-        if self._root_locator is None:
-            return self.root is not None
-        else:
-            return self.page.is_element_displayed(*self._root_locator)
+        return self.root.is_displayed()
 
     def wait_for_region_to_display(self):
-        self.wait.until(lambda _: self.is_displayed)
+        self.page.wait_for_region_to_display(self)
         return self
+
+    def wait_for_element_to_display(self, element):
+        return self.page.wait_for_element_to_display(element)
 
     def scroll_to(self, element=None):
-        """Scrolls to the given element (or the region's root). Returns the region."""
+        """Scrolls to the given element (or the region's root). Returns the element."""
         if element is None:
             element = self.root
-        self.page.scroll_to(element)
-        return self
+        return self.page.scroll_to(element)
 
     def offscreen_click(self, element=None):
-        """Scrolls to the given element (or the region's root) and clicks it. Returns the region."""
+        """Clicks an offscreen element (or the region's root).
+
+        Clicks the given element, even if it is offscreen, by sending the ENTER key.
+        Returns the element.
+        """
         if element is None:
             element = self.root
-        self.page.offscreen_click(element)
-        return self
+        return self.page.offscreen_click(element)

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -275,7 +275,8 @@ def test_nav_and_menus_display_after_scrolling(webview_base_url, selenium):
     content = book.click_book_cover()
 
     # WHEN we scroll to the bottom
-    footer = content.content_footer.scroll_to()
+    footer = content.content_footer
+    footer.scroll_to()
 
     # THEN the content nav is displayed on top without the site navbar or any social links
     # The header nav is offscreen but still considered displayed
@@ -341,8 +342,7 @@ def test_back_to_top(webview_base_url, selenium):
     footer = content.content_footer
 
     # WHEN we scroll to the bottom then click the back to top link
-    footer_nav = footer.nav.scroll_to()
-    content = footer_nav.click_back_to_top_link()
+    content = footer.nav.click_back_to_top_link()
 
     # THEN the content page is no longer scrolled
     assert content.header.is_nav_displayed

--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -46,7 +46,7 @@ def test_top_right_links_and_nav(width, height, webview_base_url, legacy_base_ur
         assert not header.is_about_us_link_displayed
         assert not header.is_donate_link_displayed
         assert not header.is_rice_logo_displayed
-        header.nav_button.click()
+        header.click_nav_button()
 
     assert header.is_browse_link_displayed
     assert header.browse_url == urljoin(webview_base_url, '/browse')

--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -199,7 +199,8 @@ def test_footer_has_correct_content_and_links(webview_base_url, selenium):
     home = Home(selenium, webview_base_url).open()
 
     # WHEN we scroll to the footer
-    footer = home.footer.scroll_to()
+    footer = home.footer
+    footer.scroll_to()
 
     # THEN the links point to the correct urls and all the content is displayed
     assert footer.is_licensing_link_displayed

--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -16,10 +16,9 @@ _number_of_tested_books = 2
 @markers.webview
 @markers.test_case('C167405')
 @markers.nondestructive
-@markers.parametrize('width,height', [(1024, 768), (640, 480)])
+@markers.parametrize('width, height', [(1024, 768), (640, 480)])
 def test_top_right_links_and_nav(width, height, webview_base_url, legacy_base_url, selenium):
-    # GIVEN the window width and height, the webview URL, the legacy URL, and the Selenium driver
-    selenium.set_window_size(width, height)
+    # GIVEN the webview URL, the legacy URL, and the Selenium driver with the window size set
 
     # WHEN the webview home page is fully loaded
     home = Home(selenium, webview_base_url).open()


### PR DESCRIPTION
Includes https://github.com/openstax/cnx-automation/pull/204 to avoid conflicts

- Wait for the hamburger menu (nav_button in content page on low resolutions) to open
- Set window size in all tests to prevent different behavior due to larger monitors