### PR TITLE
Test the ids of top nav links

### DIFF
--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -58,6 +58,7 @@ def chrome_options(language, chrome_options, pytestconfig):
         chrome_options.add_argument('--disable-dev-shm-usage')
 
     # Set the browser language
+    chrome_options.add_argument('--lang={lang}'.format(lang=language))
     chrome_options.add_experimental_option('prefs', {'intl.accept_languages': language})
 
     return chrome_options

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -7,7 +7,7 @@ import pytest
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 
-__all__ = ['selenium', 'chrome_options']
+__all__ = ['language', 'selenium', 'chrome_options']
 
 
 # https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -40,7 +40,7 @@ def selenium(request, selenium, pytestconfig):
 
 @pytest.fixture
 def language(request):
-    if request.param:
+    if hasattr(request, 'param') and isinstance(request.param, str):
         return request.param
     else:
         return 'en'

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -10,6 +10,11 @@ from lxml.etree import XMLSyntaxError
 __all__ = ['language', 'selenium', 'chrome_options']
 
 
+@pytest.fixture
+def language(request):
+    return 'en'
+
+
 # https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 @pytest.fixture
 def selenium(request, selenium, pytestconfig):
@@ -39,15 +44,7 @@ def selenium(request, selenium, pytestconfig):
 
 
 @pytest.fixture
-def language(request):
-    if hasattr(request, 'param') and isinstance(request.param, str):
-        return request.param
-    else:
-        return 'en'
-
-
-@pytest.fixture
-def chrome_options(language, chrome_options, pytestconfig):
+def chrome_options(chrome_options, language, pytestconfig):
     if pytestconfig.getoption('--headless'):
         chrome_options.headless = True
 

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -39,7 +39,15 @@ def selenium(request, selenium, pytestconfig):
 
 
 @pytest.fixture
-def chrome_options(chrome_options, pytestconfig):
+def language(request):
+    if request.param:
+        return request.param
+    else:
+        return 'en'
+
+
+@pytest.fixture
+def chrome_options(language, chrome_options, pytestconfig):
     if pytestconfig.getoption('--headless'):
         chrome_options.headless = True
 
@@ -49,8 +57,7 @@ def chrome_options(chrome_options, pytestconfig):
     if pytestconfig.getoption('--disable-dev-shm-usage'):
         chrome_options.add_argument('--disable-dev-shm-usage')
 
-    # This ensures the tests will still pass for someone who selected
-    # a language other than English as their preferred language in Chrome
-    chrome_options.add_argument('--lang=en')
+    # Set the browser language
+    chrome_options.add_experimental_option('prefs', {'intl.accept_languages': language})
 
     return chrome_options

--- a/fixtures/base.py
+++ b/fixtures/base.py
@@ -7,7 +7,17 @@ import pytest
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 
-__all__ = ['language', 'selenium', 'chrome_options']
+__all__ = ['width', 'height', 'language', 'selenium', 'chrome_options']
+
+
+@pytest.fixture
+def width(request):
+    return 1024
+
+
+@pytest.fixture
+def height(request):
+    return 768
 
 
 @pytest.fixture
@@ -17,8 +27,8 @@ def language(request):
 
 # https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 @pytest.fixture
-def selenium(request, selenium, pytestconfig):
-    selenium.implicitly_wait(0)
+def selenium(selenium, pytestconfig, width, height, request):
+    selenium.set_window_size(width, height)
     yield selenium
     # request.node is an "item" because we use the default "function" scope
     if pytestconfig.getoption('--print-page-source-on-failure') and \
@@ -44,7 +54,7 @@ def selenium(request, selenium, pytestconfig):
 
 
 @pytest.fixture
-def chrome_options(chrome_options, language, pytestconfig):
+def chrome_options(chrome_options, pytestconfig, language):
     if pytestconfig.getoption('--headless'):
         chrome_options.headless = True
 

--- a/pages/webview/base.py
+++ b/pages/webview/base.py
@@ -33,16 +33,6 @@ class Page(pypom.Page):
         ActionChains(self.driver).move_to_element(element).perform()
         return element
 
-    def focus(self, element):
-        """Focus (and scrolls to) the given element.
-
-        Focus (and scrolls to) the given element.
-        More reliable than scroll_to(), but can only be used on focusable elements.
-        Returns the element.
-        """
-        element.send_keys('')
-        return element
-
     def offscreen_click(self, element):
         """Clicks an offscreen element.
 

--- a/pages/webview/base.py
+++ b/pages/webview/base.py
@@ -57,8 +57,11 @@ class Page(pypom.Page):
         )
         _nav_button_locator = (By.CSS_SELECTOR,
                                '#header button.navbar-toggle[data-target="#page-nav"]')
+        _browse_li_locator = (By.XPATH, ".//li[.//a[text()='Search']]")
         _browse_link_locator = (By.CSS_SELECTOR, '#page-nav #nav-browse a')
+        _about_us_li_locator = (By.XPATH, ".//li[.//a[text()='About Us']]")
         _about_us_link_locator = (By.CSS_SELECTOR, '#page-nav #nav-about a')
+        _donate_li_locator = (By.XPATH, ".//li[.//a[text()='Give']]")
         _donate_link_locator = (By.CSS_SELECTOR, '#page-nav #nav-donate a')
         _rice_logo_locator = (By.XPATH, ".//a[.//img[@src='/images/rice.png']]")
 
@@ -107,6 +110,14 @@ class Page(pypom.Page):
             return self.is_element_displayed(*self._nav_button_locator)
 
         @property
+        def browse_li(self):
+            return self.find_element(*self._browse_li_locator)
+
+        @property
+        def browse_li_id(self):
+            return self.browse_li.get_attribute('id')
+
+        @property
         def browse_link(self):
             return self.find_element(*self._browse_link_locator)
 
@@ -119,6 +130,14 @@ class Page(pypom.Page):
             return self.browse_link.get_attribute('href')
 
         @property
+        def about_us_li(self):
+            return self.find_element(*self._about_us_li_locator)
+
+        @property
+        def about_us_li_id(self):
+            return self.about_us_li.get_attribute('id')
+
+        @property
         def about_us_link(self):
             return self.find_element(*self._about_us_link_locator)
 
@@ -129,6 +148,14 @@ class Page(pypom.Page):
         @property
         def about_us_url(self):
             return self.about_us_link.get_attribute('href')
+
+        @property
+        def donate_li(self):
+            return self.find_element(*self._donate_li_locator)
+
+        @property
+        def donate_li_id(self):
+            return self.donate_li.get_attribute('id')
 
         @property
         def donate_link(self):

--- a/pages/webview/base.py
+++ b/pages/webview/base.py
@@ -27,8 +27,19 @@ class Page(pypom.Page):
         self.wait.until(lambda _: element.is_displayed())
         return self
 
+    def scroll_to(self, element=None):
+        """Scrolls to the given element. Returns the element."""
+        from selenium.webdriver.common.action_chains import ActionChains
+        ActionChains(self.driver).move_to_element(element).perform()
+        return element
+
     def focus(self, element):
-        """Focus (and scrolls to) the given element. Returns the element."""
+        """Focus (and scrolls to) the given element.
+
+        Focus (and scrolls to) the given element.
+        More reliable than scroll_to(), but can only be used on focusable elements.
+        Returns the element.
+        """
         element.send_keys('')
         return element
 

--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -127,6 +127,8 @@ class Content(Page):
             By.CSS_SELECTOR,
             'div.info span[data-l10n-id="textbook-view-book-by"] span.collection-authors'
         )
+        _derived_from_span_locator = (By.CSS_SELECTOR,
+                                      'span[data-l10n-id="textbook-view-derived-from"]')
 
         # The title and author divs can be reloaded at seemingly random times so we must
         # retry StaleElementReferenceExceptions using retry_stale_element_reference_exception
@@ -159,6 +161,18 @@ class Content(Page):
         @retry_stale_element_reference_exception
         def author(self):
             return self.find_element(*self._author_span_locator).text
+
+        @property
+        def is_derived_from_displayed(self):
+            return self.is_element_displayed(*self._derived_from_span_locator)
+
+        @property
+        def derived_from_span(self):
+            return self.find_element(*self._derived_from_span_locator)
+
+        @property
+        def derived_from_text(self):
+            return self.derived_from_span.text
 
         @property
         def share(self):

--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -526,11 +526,11 @@ class Content(Page):
             return self.Attribution(self.page)
 
         def click_downloads_tab(self):
-            self.scroll_to().downloads_tab.click()
+            self.offscreen_click(self.downloads_tab)
             return self.downloads.wait_for_region_to_display()
 
         def click_attribution_tab(self):
-            self.scroll_to().attribution_tab.click()
+            self.offscreen_click(self.attribution_tab)
             return self.attribution.wait_for_region_to_display()
 
         class Downloads(Region):
@@ -600,7 +600,7 @@ class Content(Page):
 
             def click_back_link(self):
                 current_url = self.driver.current_url
-                self.scroll_to().back_link.click()
+                self.offscreen_click(self.back_link)
                 return self.page.wait_for_url_to_change(current_url)
 
             def click_back_to_top_link(self):
@@ -609,5 +609,5 @@ class Content(Page):
 
             def click_next_link(self):
                 current_url = self.driver.current_url
-                self.scroll_to().next_link.click()
+                self.offscreen_click(self.next_link)
                 return self.page.wait_for_url_to_change(current_url)

--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -604,7 +604,7 @@ class Content(Page):
                 return self.page.wait_for_url_to_change(current_url)
 
             def click_back_to_top_link(self):
-                self.back_to_top_link.click()
+                self.offscreen_click(self.back_to_top_link)
                 return self.page.wait_for_page_to_load()
 
             def click_next_link(self):

--- a/pages/webview/home.py
+++ b/pages/webview/home.py
@@ -56,19 +56,19 @@ class Home(Page):
             return self.find_element(*self._book_intro_locator).text
 
         def click_read_more(self):
-            self.scroll_to().find_element(*self._read_more_locator).click()
+            self.offscreen_click(self.find_element(*self._read_more_locator))
             from pages.webview.content import Content
             content = Content(self.driver, self.page.base_url, self.page.timeout)
             return content.wait_for_page_to_load()
 
         def click_book_cover(self):
-            self.scroll_to().find_element(*self._book_cover_link_locator).click()
+            self.offscreen_click(self.find_element(*self._book_cover_link_locator))
             from pages.webview.content import Content
             content = Content(self.driver, self.page.base_url, self.page.timeout)
             return content.wait_for_page_to_load()
 
         def click_title_link(self):
-            self.scroll_to().find_element(*self._title_link_locator).click()
+            self.offscreen_click(self.find_element(*self._title_link_locator))
             from pages.webview.content import Content
             content = Content(self.driver, self.page.base_url, self.page.timeout)
             return content.wait_for_page_to_load()

--- a/regions/webview/base.py
+++ b/regions/webview/base.py
@@ -39,17 +39,6 @@ class Region(pypom.Region):
             element = self.root
         return self.page.scroll_to(element)
 
-    def focus(self, element=None):
-        """Focus (and scrolls to) the given element (or the region's root).
-
-        Focus (and scrolls to) the given element (or the region's root).
-        More reliable than scroll_to(), but can only be used on focusable elements.
-        Returns the element.
-        """
-        if element is None:
-            element = self.root
-        return self.page.focus(element)
-
     def offscreen_click(self, element=None):
         """Clicks an offscreen element (or the region's root).
 

--- a/regions/webview/base.py
+++ b/regions/webview/base.py
@@ -24,25 +24,27 @@ class Region(pypom.Region):
 
     @property
     def is_displayed(self):
-        if self._root_locator is None:
-            return self.root is not None
-        else:
-            return self.page.is_element_displayed(*self._root_locator)
+        return self.root.is_displayed()
 
     def wait_for_region_to_display(self):
-        self.wait.until(lambda _: self.is_displayed)
+        self.page.wait_for_region_to_display(self)
         return self
 
-    def scroll_to(self, element=None):
-        """Scrolls to the given element (or the region's root). Returns the region."""
+    def wait_for_element_to_display(self, element):
+        return self.page.wait_for_element_to_display(element)
+
+    def focus(self, element=None):
+        """Focus (and scrolls to) the given element (or the region's root). Returns the element."""
         if element is None:
             element = self.root
-        self.page.scroll_to(element)
-        return self
+        return self.page.focus(element)
 
     def offscreen_click(self, element=None):
-        """Scrolls to the given element (or the region's root) and clicks it. Returns the region."""
+        """Clicks an offscreen element (or the region's root).
+
+        Clicks the given element, even if it is offscreen, by sending the ENTER key.
+        Returns the element.
+        """
         if element is None:
             element = self.root
-        self.page.offscreen_click(element)
-        return self
+        return self.page.offscreen_click(element)

--- a/regions/webview/base.py
+++ b/regions/webview/base.py
@@ -33,8 +33,19 @@ class Region(pypom.Region):
     def wait_for_element_to_display(self, element):
         return self.page.wait_for_element_to_display(element)
 
+    def scroll_to(self, element=None):
+        """Scrolls to the given element (or the region's root). Returns the element."""
+        if element is None:
+            element = self.root
+        return self.page.scroll_to(element)
+
     def focus(self, element=None):
-        """Focus (and scrolls to) the given element (or the region's root). Returns the element."""
+        """Focus (and scrolls to) the given element (or the region's root).
+
+        Focus (and scrolls to) the given element (or the region's root).
+        More reliable than scroll_to(), but can only be used on focusable elements.
+        Returns the element.
+        """
         if element is None:
             element = self.root
         return self.page.focus(element)

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -276,7 +276,7 @@ def test_nav_and_menus_display_after_scrolling(webview_base_url, selenium):
 
     # WHEN we scroll to the bottom
     footer = content.footer
-    footer.focus(footer.downloads_tab)
+    footer.scroll_to()
 
     # THEN the content nav is displayed on top without the site navbar or any social links
     # The header nav is offscreen but still considered displayed

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -259,7 +259,7 @@ def test_content_and_figures_display_after_scrolling(webview_base_url, selenium)
     assert content_region.has_figures
 
     # WHEN we scroll to a figure
-    content_region.scroll_to(content_region.figures[0])
+    content_region.focus(content_region.figures[0])
 
     # THEN some figure is displayed
     assert content_region.is_figure_displayed
@@ -275,7 +275,8 @@ def test_nav_and_menus_display_after_scrolling(webview_base_url, selenium):
     content = book.click_book_cover()
 
     # WHEN we scroll to the bottom
-    footer = content.footer.scroll_to()
+    footer = content.footer
+    footer.focus(footer.downloads_tab)
 
     # THEN the content nav is displayed on top without the site navbar or any social links
     # The header nav is offscreen but still considered displayed
@@ -341,8 +342,7 @@ def test_back_to_top(webview_base_url, selenium):
     footer = content.footer
 
     # WHEN we scroll to the bottom then click the back to top link
-    footer_nav = footer.nav.scroll_to()
-    content = footer_nav.click_back_to_top_link()
+    content = footer.nav.click_back_to_top_link()
 
     # THEN the content page is no longer scrolled
     assert content.header.is_nav_displayed

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -77,6 +77,29 @@ def test_author_is_openstax(webview_base_url, selenium):
 
 
 @markers.webview
+@markers.test_case('C189063')
+@markers.nondestructive
+# https://stackoverflow.com/a/33879151
+@markers.parametrize('language', ['en', 'pl'], indirect=True)
+@markers.parametrize('uuid', ['d6e3aa5a-10a9-4436-9d16-ae3b1d71ac8b'])
+def test_derived_from_content(webview_base_url, selenium, language, uuid):
+    # GIVEN the selenium driver set to a specific language and a derived book's uuid
+
+    # WHEN we visit the derived book's content page
+    content = Content(selenium, webview_base_url, id=uuid).open()
+
+    # THEN we get "derived from" text appropriate for the given language
+    content_header = content.content_header
+
+    assert content_header.is_derived_from_displayed
+
+    if language == 'en':
+        assert content_header.derived_from_text == 'Derived from Biology by OpenStax'
+    elif language == 'pl':
+        assert content_header.derived_from_text == 'Utworzone z Biology autorstwa OpenStax'
+
+
+@markers.webview
 @markers.test_case('C176242')
 @markers.nondestructive
 def test_toc_is_displayed(webview_base_url, selenium):

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -80,7 +80,7 @@ def test_author_is_openstax(webview_base_url, selenium):
 @markers.test_case('C189063')
 @markers.nondestructive
 # https://stackoverflow.com/a/33879151
-@markers.parametrize('language', ['en', 'pl'], indirect=True)
+@markers.parametrize('language', ['en', 'pl'])
 @markers.parametrize('uuid', ['d6e3aa5a-10a9-4436-9d16-ae3b1d71ac8b'])
 def test_derived_from_content(webview_base_url, selenium, language, uuid):
     # GIVEN the selenium driver set to a specific language and a derived book's uuid

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -259,7 +259,7 @@ def test_content_and_figures_display_after_scrolling(webview_base_url, selenium)
     assert content_region.has_figures
 
     # WHEN we scroll to a figure
-    content_region.focus(content_region.figures[0])
+    content_region.scroll_to(content_region.figures[0])
 
     # THEN some figure is displayed
     assert content_region.is_figure_displayed

--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -44,7 +44,7 @@ def test_top_right_links_and_nav(width, height, webview_base_url, legacy_base_ur
         assert not header.is_about_us_link_displayed
         assert not header.is_donate_link_displayed
         assert not header.is_rice_logo_displayed
-        header.nav_button.click()
+        header.click_nav_button()
 
     assert header.is_browse_link_displayed
     assert header.browse_url == '{webview_url}/browse'.format(webview_url=webview_base_url)

--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -14,10 +14,9 @@ _number_of_tested_books = 2
 @markers.webview
 @markers.test_case('C167405')
 @markers.nondestructive
-@markers.parametrize('width,height', [(1024, 768), (640, 480)])
+@markers.parametrize('width, height', [(1024, 768), (640, 480)])
 def test_top_right_links_and_nav(width, height, webview_base_url, legacy_base_url, selenium):
-    # GIVEN the window width and height, the webview URL, the legacy URL, and the Selenium driver
-    selenium.set_window_size(width, height)
+    # GIVEN the webview URL, the legacy URL, and the Selenium driver with the window size set
 
     # WHEN the webview home page is fully loaded
     home = Home(selenium, webview_base_url).open()

--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -15,7 +15,8 @@ _number_of_tested_books = 2
 @markers.test_case('C167405')
 @markers.nondestructive
 @markers.parametrize('width, height', [(1024, 768), (640, 480)])
-def test_top_right_links_and_nav(width, height, webview_base_url, legacy_base_url, selenium):
+def test_top_right_links_and_nav_are_displayed_and_have_ids(width, height, webview_base_url,
+                                                            legacy_base_url, selenium):
     # GIVEN the webview URL, the legacy URL, and the Selenium driver with the window size set
 
     # WHEN the webview home page is fully loaded
@@ -46,12 +47,15 @@ def test_top_right_links_and_nav(width, height, webview_base_url, legacy_base_ur
         header.click_nav_button()
 
     assert header.is_browse_link_displayed
+    assert header.browse_li_id == 'nav-browse'
     assert header.browse_url == '{webview_url}/browse'.format(webview_url=webview_base_url)
 
     assert header.is_about_us_link_displayed
+    assert header.about_us_li_id == 'nav-about'
     assert header.about_us_url == '{webview_url}/about'.format(webview_url=webview_base_url)
 
     assert header.is_donate_link_displayed
+    assert header.donate_li_id == 'nav-donate'
     assert header.donate_url == '{webview_url}/donate'.format(webview_url=webview_base_url)
 
     assert header.is_rice_logo_displayed


### PR DESCRIPTION
https://github.com/openstax/cnx-automation/issues/169

I could instead reverse the test case and select by ID as usual and just test the text of the links instead of using these crazy XPATHs.

Based on https://github.com/openstax/cnx-automation/pull/205 to avoid conflicts. Look at only the last commit for diff.