### PR TITLE
removed unneeded map test and updates to email and header tests

### DIFF
--- a/pages/webview/contact.py
+++ b/pages/webview/contact.py
@@ -20,15 +20,10 @@ class Contact(AboutPage):
         return self.contact_content.loaded and super().loaded
 
     class ContactContent(Region):
-        _root_locator = (By.CSS_SELECTOR, '#about .about-content div.contact')
-        _email_link_locator = (By.CSS_SELECTOR, 'span[data-l10n-id="about-contact-email"] a')
-        _map_img_locator = (By.CSS_SELECTOR, 'img[src="/locale/en-US/images/map.png"]')
+        _root_locator = (By.ID, 'about')
+        _email_link_locator = (By.CSS_SELECTOR, '.contact > p:nth-child(5) > a')
         _questions_header_locator = (
             By.CSS_SELECTOR, '[data-l10n-id="about-contact-questions-header"]')
-        _technical_support_header_locator = (
-            By.CSS_SELECTOR, '[data-l10n-id="about-contact-technical-support-header"]')
-        _general_questions_header_locator = (
-            By.CSS_SELECTOR, '[data-l10n-id="about-contact-general-questions-header"]')
 
         @property
         def is_email_displayed(self):
@@ -43,23 +38,5 @@ class Contact(AboutPage):
             return self.email_link.get_attribute('href')
 
         @property
-        def is_map_displayed(self):
-            return self.is_element_displayed(*self._map_img_locator)
-
-        @property
         def questions_header(self):
             return self.find_element(*self._questions_header_locator)
-
-        @property
-        def technical_support_header(self):
-            return self.find_element(*self._technical_support_header_locator)
-
-        @property
-        def general_questions_header(self):
-            return self.find_element(*self._general_questions_header_locator)
-
-        @property
-        def loaded(self):
-            # super().loaded checks that the Region root element is present
-            # is_map_displayed waits until the map has at least started loading
-            return super().loaded and self.is_map_displayed

--- a/tests/webview/ui/test_contact.py
+++ b/tests/webview/ui/test_contact.py
@@ -25,24 +25,9 @@ def test_contact_has_correct_email_link(webview_base_url, selenium):
 
 
 @markers.webview
-@markers.test_case('C176253')
-@markers.nondestructive
-def test_contact_has_location_map(webview_base_url, selenium):
-    # GIVEN the About Us page
-    home = Home(selenium, webview_base_url).open()
-    about_us = home.header.click_about_us()
-
-    # WHEN the contact link in the navbar is clicked
-    contact = about_us.click_contact()
-
-    # THEN a map of the location of OpenStax is displayed
-    assert contact.contact_content.is_map_displayed
-
-
-@markers.webview
 @markers.test_case('C176256')
 @markers.nondestructive
-def test_contact_has_correct_headers(webview_base_url, selenium):
+def test_contact_has_questions_header(webview_base_url, selenium):
     # GIVEN the About Us page
     home = Home(selenium, webview_base_url).open()
     about_us = home.header.click_about_us()
@@ -50,7 +35,5 @@ def test_contact_has_correct_headers(webview_base_url, selenium):
     # WHEN the contact link in the navbar is clicked
     contact = about_us.click_contact()
 
-    # THEN the Questions?, Technical Support and General Questions headers are displayed
+    # THEN the Questions? header is displayed
     assert contact.contact_content.questions_header.text == 'Questions?'
-    assert contact.contact_content.technical_support_header.text == 'Technical Support'
-    assert contact.contact_content.general_questions_header.text == 'General Questions'


### PR DESCRIPTION
The contact page has changed considerably. There were various headers we checked for that have been removed.

* Changed `test_contact_has_correct_headers` to `test_contact_has_questions_header`
* Removed test_contact_has_location_map b/c map has been removed
* Removed unnecessary locators from contact page that were used for headers and map
