### PR TITLE
Testing webview and archive integration using the latest images

### DIFF
--- a/.dockerfiles/cnx.vcl
+++ b/.dockerfiles/cnx.vcl
@@ -1,0 +1,539 @@
+# FIXME: Drop the clusters since the load balancing is redundant in the container world.
+# FIXME: The host name is hardcoded to cnx.org
+
+vcl 4.0;
+
+import std;
+import directors;
+
+# This configuration uses inline C, so you must run the program with
+# the include C parameter: -r vcc_allow_inline_c
+
+# This is a basic VCL configuration file for varnish.  See the vcl(7)
+# man page for details on VCL syntax and semantics.
+# C{
+#         #include <string.h>
+#         #include <stdlib.h>
+#         #include <time.h>
+
+#         void TIM_format(double t, char *p);
+#         double TIM_real(void);
+#         time_t TIM_parse(const char *p);
+# }C
+
+acl block {
+}
+
+# Needed for cnx.org/.*/enqueue and *format=rdf for PDFgen
+# haproxy load balancing for zope
+backend legacy_frontend {
+.host = "legacy-ui";
+.port = "8080";
+.connect_timeout = 0.4s;
+.first_byte_timeout = 1200s;
+.between_bytes_timeout = 600s;
+}
+
+
+# static files
+backend static_files {
+.host = "files-server";
+.port = "8080";
+.connect_timeout = 0.4s;
+.first_byte_timeout = 60s;
+.between_bytes_timeout = 10s;
+}
+
+backend webview {
+.host = "ui";
+.port = "8000";
+.connect_timeout = 0.4s;
+.first_byte_timeout = 600s;
+.between_bytes_timeout = 60s;
+}
+
+probe archive_probe {
+    .expected_response = 404;
+}
+
+backend archive {
+.host = "archive";
+.port = "6543";
+.probe = archive_probe;
+.connect_timeout = 0.4s;
+.first_byte_timeout = 600s;
+.between_bytes_timeout = 60s;
+}
+
+probe publishing_probe {
+    .expected_response = 404;
+}
+
+backend publishing {
+.host = "publishing";
+.port = "6543";
+.probe = publishing_probe;
+.first_byte_timeout = 600s;
+.between_bytes_timeout = 60s;
+}
+
+probe press_probe {
+    .url = "/ping";
+    .expected_response = 200;
+}
+
+backend press {
+.host = "press";
+.port = "press";
+.probe = press_probe;
+.first_byte_timeout = 600s;
+.between_bytes_timeout = 60s;
+}
+
+acl purge {
+    "localhost";
+    "127.0.0.1";
+    "publishing";
+    "press";
+}
+
+acl nocache {
+    "127.0.0.1";
+    "10.0.0.0"/8;
+}
+
+
+sub vcl_init {
+    # Define the archive and resource clusters
+    new archive_cluster = directors.round_robin();
+    new resource_cluster = directors.round_robin();
+    archive_cluster.add_backend(archive);
+    resource_cluster.add_backend(archive);
+
+    # Define the publishing cluster
+    new publishing_cluster = directors.hash();
+    publishing_cluster.add_backend(publishing, 1.0);
+
+    # Define the Press cluster
+    new press_cluster = directors.hash();
+    press_cluster.add_backend(press, 1.0);
+}
+
+sub vcl_recv {
+
+    if (client.ip ~ block) {
+        return (synth(403, "Access denied"));
+    }
+
+    if (req.url ~ "^/ping") {
+        set req.backend_hint = webview;
+        return (pass);
+    }
+
+    if (req.url ~ "^/api/") {
+       set req.backend_hint = press_cluster.backend(req.http.cookie);
+       # let the client talk directly to Press,
+       # because litezip publishing payloads are huge.
+       return (pipe);
+    }
+
+    # stub login form
+    if (req.url ~ "^/stub-login-form") {
+        set req.backend_hint = publishing_cluster.backend(req.http.cookie);
+        return (pass);
+    }
+
+    # admin interface
+    if (req.url ~ "^/a/") {
+        set req.backend_hint = publishing_cluster.backend(req.http.cookie);
+        return (pass);
+    }
+
+    # archive and publishing  - specials served from nginx statically
+    if (req.http.host ~ "^cnx.org" || req.url ~ "^/sitemap.*.xml") {
+
+        if (req.url  == "/robots.txt" || req.url ~ "^/specials") {
+            set req.backend_hint = static_files;
+            return (hash);
+        }
+
+        elsif ( req.method == "POST" || req.method == "PUT" || req.method == "DELETE" || req.url ~ "^/(publications|callback|a|login|logout|moderations|feeds/moderations.rss|contents/.*/(licensors|roles|permissions))") {
+            set req.backend_hint = publishing_cluster.backend(req.http.cookie);
+            return (pass);
+        }
+
+        elsif ( req.url ~ "^/exports/") {
+            set req.backend_hint = archive_cluster.backend();
+            return (pass);
+        }
+
+        elsif (req.url ~ "^/resources/") {
+            set req.backend_hint = resource_cluster.backend();
+            return (hash);
+        }
+
+        else {
+            set req.backend_hint = archive_cluster.backend();
+            return (hash);
+        }
+    }
+
+    # resource images
+    if (req.url ~ "^/resources/") {
+        set req.backend_hint = resource_cluster.backend();
+        return (hash);
+    }
+
+    elsif ( req.url ~ "^/exports/") {
+        set req.backend_hint = archive_cluster.backend();
+        return (pass);
+    }
+
+
+    # FIXME req.grace cannot be used here, see also
+    #       https://www.varnish-cache.org/docs/4.0/users-guide/vcl-grace.html
+    # set req.grace = 120s;
+    if (req.http.host ~ "^cnx.org(:[0-9]+)?$") {
+
+        /* doing the static file dance */
+        if (req.url ~ "^/pdfs") {
+            set req.backend_hint = static_files;
+            set req.url = regsub(req.url, "^/pdfs", "/files");
+        }
+        elsif (req.restarts == 0  && req.url ~ "^/content/.*/enqueue") {
+            set req.backend_hint = legacy_frontend;
+            return(pass);
+        }
+        elsif (req.restarts == 0  && req.url ~ "^/content/col.*/?\?format=rdf") {
+            set req.backend_hint = legacy_frontend;
+            return(hash);
+        }
+        elsif (req.restarts == 0  && req.url ~ "^/content/.*/module_export_template") {
+            set req.backend_hint = legacy_frontend;
+            return(hash);
+        }
+        elsif (req.restarts == 0  && req.url ~ "^/content/(m[0-9]+)/([0-9.]+)/.*format=pdf$") {
+            set req.backend_hint = static_files;
+            set req.url = regsub(req.url, "^/content/(m[0-9]+)/([0-9.]+)/.*format=pdf", "/files/\1-\2.pdf");
+        }
+        elsif (req.restarts == 1  && req.url ~ "^/files/(m[0-9]+)-([0-9.]+)\.pdf") {
+            set req.backend_hint = legacy_frontend;
+            set req.url = regsub(req.url, "^/files/(m[0-9]+)-([0-9.]+)\.pdf", "/content/\1/\2/?format=pdf");
+        }
+        elsif (req.url ~ "^/content/((col|m)[0-9]+)/latest/(pdf|epub)$") {
+            set req.backend_hint = legacy_frontend;
+            return(hash);
+        }
+        elsif (req.url ~ "^/content/((col|m)[0-9]+)/([0-9.]+)/(pdf|epub)$") {
+            set req.backend_hint = static_files;
+            set req.url = regsub(req.url, "^/content/((col|m)[0-9]+)/([0-9.]+)/.*(pdf|epub)", "/files/\1-\3.\4");
+        }
+        elsif (req.url ~ "^/content/((col|m)[0-9]+)/([0-9.]+)/(complete|offline)$") {
+            set req.backend_hint = static_files;
+            set req.url = regsub(req.url, "^/content/((col|m)[0-9]+)/([0-9.]+)/(complete|offline)", "/files/\1-\3.\4.zip");
+        }
+        elsif (req.url ~ "^/content/(col[0-9]+)/([0-9.]+)/source$") {
+            set req.backend_hint = static_files;
+            set req.url = regsub(req.url, "^/content/(col[0-9]+)/([0-9.]+)/source", "/files/\1-\2.xml");
+        }
+        elsif (req.url ~ "^/content/((col|m)[0-9]+)") {
+            set req.backend_hint = archive_cluster.backend();
+        }
+        // all webview
+        elsif (req.url ~ "_escaped_fragment_=" || req.url ~ "^/$" || req.url ~ "^/?.*" || req.url ~ "^/opensearch\.xml" || req.url ~ "^/version\.txt" || req.url ~ "^/search" || req.url ~ "^/contents$" || req.url ~ "^/(contents|data|exports|styles|fonts|bower_components|node_modules|images|scripts)/" || req.url ~ "^/(about|about-us|people|contents|donate|tos|browse)" || req.url ~ "^/(login|logout|workspace|callback|users|publish|robots.txt)") {
+            set req.backend_hint = webview;
+
+        }
+    }
+    else {
+        return (synth(750, "Moved Permanently"));
+    }
+
+    if (req.method == "PURGE") {
+        # Change varnish to use `req.http.x-forwarded-for` instead of `client.ip`
+        # because `client.ip` has the IP address of haproxy (I think).
+        # `req.http-x-forwarded-for` sometimes has multiple IP addresses because
+        # of redirects within our servers, the first IP is what we want, so remove
+        # everything after ",".
+        if (!std.ip(regsub(req.http.x-forwarded-for, ",.*$", ""), "0.0.0.0") ~ purge) {
+            return (synth(405, client.ip));
+        }
+        ban("req.url ~ " + req.url + "$");
+        return (synth(200, "Ban added"));
+    }
+   if (req.method == "PURGE_REGEXP") {
+        # Change varnish to use `req.http.x-forwarded-for` instead of `client.ip`
+        # because `client.ip` has the IP address of haproxy (I think).
+        # `req.http-x-forwarded-for` sometimes has multiple IP addresses because
+        # of redirects within our servers, the first IP is what we want, so remove
+        # everything after ",".
+        if (!std.ip(regsub(req.http.x-forwarded-for, ",.*$", ""), "0.0.0.0") ~ purge) {
+            return (synth(405, "Not allowed."));
+        }
+        ban("req.url ~ " + req.url);
+        return (synth(200, "Regexp ban added"));
+    }
+
+    if (req.method != "GET" && req.method != "HEAD") {
+        /* We only deal with GET and HEAD by default */
+        return(pass);
+    }
+
+    if (req.http.If-None-Match) {
+        return(pass);
+    }
+
+    if (req.url ~ "createObject") {
+        return(pass);
+    }
+
+    if (req.url ~ "//$") {
+        return (synth(700, "Bad URL"));
+    }
+
+    call normalize_accept_encoding;
+    call annotate_request;
+    return(hash);
+}
+
+sub vcl_pipe {
+    # This is not necessary if you do not do any request rewriting.
+    set req.http.connection = "close";
+}
+
+sub vcl_hit {
+    if (obj.ttl <= 0s) {
+        return(pass);
+    }
+    # if (req.http.X-Force-Refresh == "refresh") {
+    #     # Allow client refresh via magic header
+    #     # FIXME https://www.varnish-cache.org/docs/4.0/whats-new/upgrading.html#obj-is-now-read-only
+    #     # set obj.ttl = 0s;
+    #     # FIXME https://www.varnish-cache.org/docs/4.0/whats-new/upgrading.html#backend-restarts-are-now-retry
+    #     # return (restart);
+
+    #     # Note, this causes the previously cached object will remain
+    #     # until its ttl has expired.
+    #     set req.hash_always_miss = true;
+    #     return(restart);
+    # }
+    if (req.http.Cache-Control ~ "no-cache") {
+        # like msnbot that send no-cache with every request.
+        if (client.ip ~ nocache) {
+            # FIXME https://www.varnish-cache.org/docs/4.0/whats-new/upgrading.html#obj-is-now-read-only
+            # set obj.ttl = 0s;
+            # FIXME https://www.varnish-cache.org/docs/4.0/whats-new/upgrading.html#backend-restarts-are-now-retry
+            # return (restart);
+
+            return(pass);
+        }
+    }
+}
+
+sub vcl_miss {
+    if (req.method == "PURGE") {
+        return (synth(404, "Not in cache"));
+    }
+
+}
+
+sub vcl_backend_response {
+    if (bereq.url ~ "^/scripts/(?:main|settings)[.]js$") {
+        set beresp.http.Cache-Control = "max-age=3600";
+    }
+    elsif (bereq.url ~ "^/locale") {
+        set beresp.http.Cache-Control = "max-age=3600";
+    }
+    if (beresp.status >= 500) {
+        set beresp.ttl = 0s;
+    }
+    if (bereq.http.X-My-Header ) {
+        set beresp.http.X-My-Header = bereq.http.X-My-Header;
+    }
+    if (beresp.status == 404 && bereq.url ~ "^/files/(m[0-9]+)-([0-9.])+\.pdf") {
+        # FIXME https://www.varnish-cache.org/docs/4.0/whats-new/upgrading.html#backend-restarts-are-now-retry
+        return(retry);
+    }
+    if (beresp.status >= 300) {
+        if (bereq.url !~ "/content/") {
+            set beresp.http.X-Varnish-Action = "FETCH (pass - status > 300, not content)";
+            set beresp.uncacheable = true;
+            return(deliver);
+        }
+    }
+
+    set beresp.grace = 120s;
+    if (beresp.ttl <= 0s) {
+        set beresp.http.X-Varnish-Action = "FETCH (pass - not cacheable)";
+        set beresp.uncacheable = true;
+        return(deliver);
+    }
+
+    if (!beresp.http.Cache-Control ~ "s-maxage=[1-9]" && beresp.http.Cache-Control ~ "(private|no-cache|no-store)") {
+        set beresp.http.X-Varnish-Action = "FETCH (pass - response sets private/no-cache/no-store token)";
+        set beresp.uncacheable = true;
+        return(deliver);
+    }
+    if (bereq.http.Authorization && !beresp.http.Cache-Control ~ "public") {
+        set beresp.http.X-Varnish-Action = "FETCH (pass - authorized and no public cache control)";
+        set beresp.uncacheable = true;
+        return(deliver);
+    }
+    if (bereq.http.X-Anonymous && !beresp.http.Cache-Control) {
+        set beresp.ttl = 600s;
+        set beresp.http.X-Varnish-Action = "FETCH (override - backend not setting cache control)";
+    }
+
+    if (bereq.http.host  ~ "^archive.cnx.org") {
+        if (bereq.url ~ "^/contents/") {
+            set beresp.ttl = 3600s;
+            set beresp.http.X-Varnish-Action = "FETCH (override - archive contents)";
+        }
+        if (bereq.url ~ "^/extras") {
+            set beresp.ttl = 600s;
+            set beresp.http.X-Varnish-Action = "FETCH (override - archive extras)";
+        }
+    }
+    if (bereq.url ~ "^/contents/") {
+        set beresp.ttl = 7d;
+        set beresp.http.X-Varnish-Action = "FETCH (override - archive contents)";
+    }
+
+    if (bereq.url ~ "^/resources") {
+        set beresp.ttl = 30d;
+        set beresp.http.X-Varnish-Action = "FETCH (override - resources)";
+    }
+
+    # Default based on %age of Last-Modified, like squid
+    if (!beresp.http.Cache-Control && !beresp.http.Expires && !beresp.http.X-Varnish-Action) {
+        # FIXME Is the following a valid replacement for this inline C?
+        #       Probably not...
+        # C{
+        #     double factor = 0.2;
+        #     double age = 0;
+        #     char *lastmod = 0;
+        #     time_t lmod;
+
+        #     lastmod = VRT_GetHdr(sp, HDR_BERESP, "\016Last-Modified:");
+        #     if (lastmod) {
+        #         lmod =  TIM_parse(lastmod);
+        #         age = TIM_real() - lmod;
+        #         VRT_l_beresp_ttl(sp, age*factor);
+        #     }
+        #  }C
+
+        # This is the attempted replacement, but it fails to compile.
+        # set beresp.ttl = std.time(beresp.http.last-modified, now);
+        # /FIXME
+        set beresp.http.X-FACTOR-TTL = "ttl: " + beresp.ttl;
+    }
+
+    if (bereq.url ~ "content/[^/]*/[0-9.]*/(\?format=)?pdf$") {
+        set beresp.http.X-My-Header = "VersionedPDF";
+        set beresp.uncacheable = true;
+        return(deliver);
+    }
+    if (bereq.url ~ "content/[^/]*/latest/(\?format=)?pdf$") {
+        set beresp.http.X-My-Header = "LatestPDF";
+        set beresp.uncacheable = true;
+        return(deliver);
+    }
+    if (bereq.url ~ "content/[^/]*/[0-9.]*/offline$") {
+        set beresp.http.X-My-Header = "VersionedOfflineZip";
+        set beresp.uncacheable = true;
+        return(deliver);
+    }
+    if (bereq.url ~ "content/[^/]*/[0-9.]*/complete$") {
+        set beresp.http.X-My-Header = "VersionedCompleteZip";
+        set beresp.uncacheable = true;
+        return(deliver);
+    }
+    call rewrite_s_maxage;
+    set beresp.http.X-FACTOR-TTL = "ttl: " + beresp.ttl;
+    return(deliver);
+}
+
+sub vcl_backend_error {
+    if (beresp.status == 750) {
+        set beresp.http.Location = "http://" + regsub(bereq.http.host, "^[^:]*", "cnx.org") + bereq.url;
+        set beresp.status = 301;
+        return(deliver);
+    } elsif (beresp.status == 700) {
+        set beresp.http.Location = bereq.http.host + regsub(bereq.url, "//$", "/");
+        set beresp.status = 301;
+        return(deliver);
+    }
+}
+
+sub vcl_deliver {
+        if (obj.hits > 0) {
+                set resp.http.X-Cache = "HIT";
+        } else {
+                set resp.http.X-Cache = "MISS";
+        }
+    call rewrite_age;
+}
+
+sub vcl_hash {
+    hash_data(req.url);
+    if (req.http.host) {
+        hash_data(req.http.host);
+    } else {
+        hash_data(server.ip);
+    }
+    if (req.http.Accept ~ "application/xhtml\+xml" && req.url ~ "^/contents/") {
+        hash_data("application/xhtml+xml");
+    }
+    return (lookup);
+}
+
+##########################
+#  Helper Subroutines
+##########################
+
+# Optimize the Accept-Encoding variant caching
+sub normalize_accept_encoding {
+    if (req.http.Accept-Encoding) {
+        if (req.url ~ "\.(jpe?g|png|gif|swf|pdf|gz|tgz|bz2|tbz|zip)$" || req.url ~ "/image_[^/]*$") {
+            unset req.http.Accept-Encoding;
+        } elsif (req.http.Accept-Encoding ~ "gzip") {
+            set req.http.Accept-Encoding = "gzip";
+        } else {
+            unset req.http.Accept-Encoding;
+        }
+    }
+}
+
+# Keep auth/anon variants apart if "Vary: X-Anonymous" is in the response
+# Also, duplicate logic of content_type_decide, in support of IE8
+sub annotate_request {
+    # X-Collection
+    if (req.http.cookie ~ "(^|.*; )courseURL=") {
+        set req.http.X-Collection = regsub(req.http.cookie, "^.*?courseURL=([^;]*);*.*$", "\1");
+    }
+    if (!(req.http.Authorization || req.http.cookie ~ "(^|.*; )__ac=" || req.http.cookie ~ "(^|.*; )cosign")) {
+        set req.http.X-Anonymous = "True";
+    }
+    if (req.http.Accept ~ "application\/xhtml\+xml") {
+        set req.http.X-Content-Type = "application/xhtml+xml";
+    } else {
+        set req.http.X-Content-Type = "text/html";
+    }
+
+}
+
+# The varnish response should always declare itself to be fresh
+sub rewrite_age {
+    if (resp.http.Age) {
+        set resp.http.X-Varnish-Age = resp.http.Age;
+        set resp.http.Age = "0";
+    }
+}
+
+# Rewrite s-maxage to exclude from intermediary proxies
+# (to cache *everywhere*, just use 'max-age' token in the response to avoid this override)
+sub rewrite_s_maxage {
+    if (beresp.http.Cache-Control ~ "s-maxage") {
+        set beresp.http.Cache-Control = regsub(beresp.http.Cache-Control, "s-maxage=[0-9]+", "s-maxage=0");
+    }
+}

--- a/.dockerfiles/proxy-openstax-org.conf
+++ b/.dockerfiles/proxy-openstax-org.conf
@@ -1,0 +1,7 @@
+server {
+    listen 80;
+
+    location / {
+        proxy_pass https://openstax.org/;
+    }
+}

--- a/.dockerfiles/settings.js
+++ b/.dockerfiles/settings.js
@@ -1,0 +1,79 @@
+(function () {
+    'use strict';
+  
+    define(function (require) {
+      var languages = require('cs!configs/languages');
+  
+      return {
+        // Directory from which webview is served
+        root: '/',
+  
+        // Hostname and port for the cnx-archive server
+        cnxarchive: {
+          host: 'archive',
+          port: 6543
+        },
+
+        // Hostname and port for the cnx-authoring server
+        cnxauthoring: {
+          host: location.hostname,
+          port: 8080
+        },
+
+        // Hostname and port for the OpenStax CMS server
+        openstaxcms: {
+          host: 'proxy-openstax-org',
+          port: 80
+        },
+  
+        // Hostname and port for the exercises server
+        exercises: {
+          host: 'exercises.openstax.org',
+          port: 443
+        },
+  
+        // Prefix to prepend to page titles
+        titleSuffix: ' - OpenStax CNX',
+  
+        // Google Analytics tracking ID
+        analyticsID: 'UA-7903479-1',
+  
+        // Supported languages
+        languages: languages,
+  
+        // Legacy URL
+        // URLs are concatenated using the following logic: location.protocol + '//' + legacy + '/' + view.url
+        //   Example: 'http:' + '//' + 'cnx.org' + '/' + 'contents'
+        // Do not include the protocol or a trailing slash
+        legacy: 'legacy.cnx.org',
+  
+        // Webmaster E-mail address
+        webmaster: 'support@openstax.org',
+  
+        // Donate E-mail address
+        donation: 'openstaxgiving@rice.edu',
+  
+        // Content shortcodes
+        shortcodes: {
+          'college-physics': '031da8d3-b525-429c-80cf-6c8ed997733a@8.1',
+          'college-introduction-to-sociology': 'afe4332a-c97f-4fc4-be27-4e4d384a32d8@7.15',
+          'biology': '185cbf87-c72e-48f5-b51e-f14f21b5eabd@9.44',
+          'concepts-of-biology': 'b3c1e1d2-839c-42b0-a314-e119a8aafbdd@8.39',
+          'anatomy-and-physiology': '14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22@6.19',
+          'introductory-statistics': '30189442-6998-4686-ac05-ed152b91b9de@17.20'
+        },
+  
+        accountProfile: 'https://accounts.cnx.org/profile',
+  
+        cnxSupport: 'https://openstax.secure.force.com/help',
+  
+        defaultLicense: {
+          code: 'by'
+        }
+  
+      };
+  
+    });
+  
+  })();
+  

--- a/.jenkins/testing
+++ b/.jenkins/testing
@@ -9,7 +9,7 @@ pipeline {
     stage('Test') {
       steps {
         withDockerServer([uri: env.SWARM_URI, credentialsId: '']) {
-          sh "docker stack deploy --prune -c docker-compose.yml -c docker-compose.test.yml cnx-automation"
+          sh "docker stack deploy --prune -c docker-compose.yml cnx-automation"
         }
       }
     }

--- a/.jenkins/testing
+++ b/.jenkins/testing
@@ -1,0 +1,17 @@
+pipeline {
+  agent { label 'docker' }
+  stages {
+    stage('Build') {
+      steps {
+        sh "docker build -t cnx-automation ."
+      }
+    }
+    stage('Test') {
+      steps {
+        withDockerServer([uri: env.SWARM_URI, credentialsId: '']) {
+          sh "docker stack deploy --prune -c docker-compose.yml -c docker-compose.test.yml cnx-automation"
+        }
+      }
+    }
+  }
+}

--- a/.jenkins/testing
+++ b/.jenkins/testing
@@ -3,7 +3,7 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        sh "docker build -t cnx-automation ."
+        sh "docker build -t openstax/cnx-automation:dev ."
       }
     }
     stage('Test') {

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,14 @@ FROM openstax/selenium-chrome-debug:latest
 
 USER root
 
+# Install wait-for and dependencies
+RUN set -x \
+  && apt-get update \
+  && apt-get install curl netcat --no-install-recommends -qqy \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl https://raw.githubusercontent.com/eficode/wait-for/828386460d138e418c31a1ebf87d9a40f5cedc32/wait-for -o /usr/local/bin/wait-for \
+  && chmod a+x /usr/local/bin/wait-for
+
 COPY --chown=seluser:seluser . /code
 
 WORKDIR /code

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ $(STATEDIR)/docker-build: Dockerfile requirements.txt
 	mkdir -p $(STATEDIR)
 	touch $(STATEDIR)/docker-build
 
-# cnx_slim_dump.sql.gz:
-# 	scp backup2.cnx.org:`ssh backup2.cnx.org 'ls -t /var/backups/cnx_slim_dump.*.sql.gz | awk "{print $1; exit}"'` cnx_slim_dump.sql.gz
+cnx_slim_dump.sql.gz:
+	scp backup2.cnx.org:`ssh backup2.cnx.org 'ls -t /var/backups/cnx_slim_dump.*.sql.gz | awk "{print $1; exit}"'` cnx_slim_dump.sql.gz
 
 
 clean: clean-build clean-pyc clean-state clean-test
@@ -39,7 +39,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr assets/
 	rm -f report.html
 
-test: ##cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
+test: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
 	docker-compose up -d selenium-chrome
 	docker-compose exec selenium-chrome wait-for db:5432 -t 900 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543 -m "webview and not (requires_deployment or requires_varnish_routing)"
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr assets/
 	rm -f report.html
 
-test: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
+test-webview: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
 	docker-compose up -d selenium-chrome
 	docker-compose exec selenium-chrome wait-for db:5432 -t 900 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543 -m "webview and not (requires_deployment or requires_varnish_routing or legacy)"
 
@@ -55,4 +55,4 @@ help:
 	@echo "clean-pyc		Remove file artifacts"
 	@echo "clean-state		Remove make's build state"
 	@echo "clean-test		Remove test artifacts"
-	@echo "test			Runs the tests in an contained environment"
+	@echo "test-webview		Runs the webview tests in an contained environment"

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ $(STATEDIR)/docker-build: Dockerfile requirements.txt
 	mkdir -p $(STATEDIR)
 	touch $(STATEDIR)/docker-build
 
-cnx_slim_dump.sql.gz:
-	scp backup2.cnx.org:`ssh backup2.cnx.org 'ls -t /var/backups/cnx_slim_dump.*.sql.gz | awk "{print $1; exit}"'` cnx_slim_dump.sql.gz
+# cnx_slim_dump.sql.gz:
+# 	scp backup2.cnx.org:`ssh backup2.cnx.org 'ls -t /var/backups/cnx_slim_dump.*.sql.gz | awk "{print $1; exit}"'` cnx_slim_dump.sql.gz
 
 
 clean: clean-build clean-pyc clean-state clean-test
@@ -39,9 +39,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr assets/
 	rm -f report.html
 
-test: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
+test: ##cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
 	docker-compose up -d selenium-chrome
-	docker-compose exec selenium-chrome wait-for db:5432 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543
+	docker-compose exec selenium-chrome wait-for db:5432 -t 900 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543 -m "webview and not (requires_deployment or requires_varnish_routing)"
 
 venv:
 	python3 -m venv .venv && \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean-test: ## remove test and coverage artifacts
 
 test: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
 	docker-compose up -d selenium-chrome
-	docker-compose exec selenium-chrome wait-for db:5432 -t 900 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543 -m "webview and not (requires_deployment or requires_varnish_routing)"
+	docker-compose exec selenium-chrome wait-for db:5432 -t 900 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543 -m "webview and not (requires_deployment or requires_varnish_routing or legacy)"
 
 venv:
 	python3 -m venv .venv && \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean-test: ## remove test and coverage artifacts
 
 test-webview: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
 	docker-compose up -d selenium-chrome
-	docker-compose exec selenium-chrome wait-for db:5432 -t 900 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543 -m "webview and not (requires_deployment or requires_varnish_routing or legacy)"
+	docker-compose exec selenium-chrome wait-for db:5432 -t 900 -- tox -- --new-first --failed-first --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543 -m "webview and not (requires_deployment or requires_varnish_routing or legacy)"
 
 venv:
 	python3 -m venv .venv && \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean-test: ## remove test and coverage artifacts
 
 test: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
 	docker-compose up -d selenium-chrome
-	docker-compose docker-compose exec selenium-chrome tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543
+	docker-compose exec selenium-chrome wait-for db:5432 -- tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543
 
 venv:
 	python3 -m venv .venv && \

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ $(STATEDIR)/docker-build: Dockerfile requirements.txt
 	mkdir -p $(STATEDIR)
 	touch $(STATEDIR)/docker-build
 
+cnx_slim_dump.sql.gz:
+	scp backup2.cnx.org:`ssh backup2.cnx.org 'ls -t /var/backups/cnx_slim_dump.*.sql.gz | awk "{print $1; exit}"'` cnx_slim_dump.sql.gz
+
+
 clean: clean-build clean-pyc clean-state clean-test
 
 clean-build: ## remove build artifacts
@@ -35,7 +39,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr assets/
 	rm -f report.html
 
-test: $(STATEDIR)/docker-build
+test: cnx_slim_dump.sql.gz $(STATEDIR)/docker-build
 	docker-compose up -d selenium-chrome
 	docker-compose docker-compose exec selenium-chrome tox -- --webview_base_url=http://ui:8000 --archive_base_url=http://archive:6543
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Follow the instructions to install [Docker Compose](https://docs.docker.com/comp
 
 ### Run Docker Compose
 
-    $ docker compose up -d
+    $ docker-compose up -d selenium-chrome
 
 ### Execute the tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
-      # TODO: Load slim data via a startup script
+      # Load slim data dump via a startup script
       - ${PWD}/cnx_slim_dump.sql.gz:/docker-entrypoint-initdb.d/cnx_slim_dump.sql.gz
     environment:
       - DB_URL=postgresql://rhaptos@/repository

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,202 @@
-version: "3"
+# TODO: artifacts volume shared with services
 
+# Note, the port mappings in this file are for developer use.
+# The mappings give the developer a way reach the service outside of the
+# container network.
+# For example, the 'archive' service is mapped to 6400:6543. When configuring
+# connections between services, use the exposed port of the container image
+# (i.e. for archive that is 6543).
+
+
+version: '3'
 services:
+  ###
+  # third-party or out-of-scope services
+  ###
+  proxy-openstax-org:
+    image: nginx:latest
+    volumes:
+      - .dockerfiles/proxy-openstax-org.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8081:80"
+
+  # TODO: MathMLCloud
+  # TODO: OpenStax Exercises
+
+  ###
+  # core third-party components
+  ###
+  rabbitmq:
+    image: rabbitmq:latest
+
+  db:
+    image: openstax/cnx-db:latest
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      # TODO: Load slim data via a startup script
+    environment:
+      - DB_URL=postgresql://rhaptos@/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@/repository
+
+  memcached:
+    image: memcached:latest
+
+  ###
+  # CNX components
+  ###
+
+  # TODO: Must touchup configuration to be strictly environ
+  archive:
+    image: openstax/cnx-archive:latest
+    # command: <use default entry-point>
+    ports:
+      - "6400:6543"
+    links:
+      - db
+      - memcached
+
+  # TODO: Must touchup configuration to be strictly environ
+  publishing:
+    image: openstax/cnx-publishing:latest
+    command: bash -c "pserve $${PYRAMID_INI}"
+    ports:
+      - "6500:6543"
+    links:
+      - db
+      - rabbitmq
+    environment:
+      - DB_URL=postgresql://rhaptos@db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository
+      - AMQP_URL=amqp://guest@rabbitmq:5672//
+      - USERS=foo\nbar\nbaz
+      - MODERATORS=foo
+      - ADMINISTRATORS=bar
+
+  channel-processing:
+    image: openstax/cnx-publishing:latest
+    command: bash -c "cnx-publishing-channel-processing $PYRAMID_INI"
+    links:
+      - db
+      - rabbitmq
+    environment:
+      # FIXME: Build PYRAMID_INI into the Dockerfile
+      - PYRAMID_INI=environ.ini
+      - DB_URL=postgresql://rhaptos@db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository
+      - AMQP_URL=amqp://guest@rabbitmq:5672//
+
+  publishing-worker:
+    image: openstax/cnx-publishing:latest
+    command: celery worker -A cnxpublishing -Q default,deferred --loglevel debug
+    links:
+      - db
+      - rabbitmq
+      - memcached
+      # TODO: link mathmlcloud
+      # - mathmlcloud
+      # TODO: link exercises
+      # - exercises
+    environment:
+      # FIXME: Build PYRAMID_INI into the Dockerfile
+      - PYRAMID_INI=environ.ini
+      - DB_URL=postgresql://rhaptos@db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository
+      - AMQP_URL=amqp://guest@rabbitmq:5672//
+      # TODO: Need to add this to the environ.ini
+      - MEMCACHE_HOST=memcached
+      # TODO: Need to add this to the environ.ini
+      - EXERCISES_URL=http://exercises
+      # TODO: Need to add this to the environ.ini
+      - MATHMLCLOUD_URL=???
+
+  press:
+    image: openstax/cnx-press:latest
+    command: gunicorn -b 0.0.0.0:6543 --access-logfile - --error-logfile - -n press --reload wsgi:app --timeout=180
+    ports:
+      - "6700:6543"
+    links:
+      - db
+      - rabbitmq
+    environment:
+      - SHARED_DIR=/app/var
+      - DB_URL=postgresql://rhaptos@db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository
+      - AMQP_URL=amqp://guest@rabbitmq:5672//
+
+  press-worker:
+    image: openstax/cnx-press:latest
+    command: celery -A press worker --beat --loglevel debug
+    links:
+      - db
+      - rabbitmq
+    environment:
+      - SHARED_DIR=/app/var
+      - DB_URL=postgresql://rhaptos@db/repository
+      - DB_SUPER_URL=postgresql://rhaptos_admin@db/repository
+      - AMQP_URL=amqp://guest@rabbitmq:5672//
+
+
+  # # TODO: AHH!!! Why is this thing still alive?!?!
+  # zeo:
+  #   image: openstax/cnx-legacy:latest
+
+  # pdf-gen:
+  #   image: openstax/cnx-legacy:latest
+  #   links:
+  #     - zeo
+
+  # legacy-ui:
+  #   image: openstax/cnx-legacy:latest
+  #   links:
+  #     - zeo
+  # !!! Place holder to allow our varnish config to resolve the address !!!
+  legacy-ui:
+      image: openstax/cnx-webview:latest
+      ports:
+        - 8080:8000
+
+  ui:
+    image: openstax/cnx-webview:latest
+    ports:
+      - 8000:8000
+    environment:
+      - ENVIRONMENT=prod
+    volumes:
+      - .dockerfiles/settings.js:/code/dist/scripts/settings.js:z
+
+  files-server:
+    # TODO: We're using nginx in production, but this works for the moment.
+    image: python:3
+    command: python -m http.server 9000 --directory /artifacts
+    ports:
+      - 9000:9000
+    volumes:
+      - artifacts:/artifacts:z
+
+  # TODO: Keep an eye on https://github.com/docker-library/official-images/pull/4404
+  varnish:
+    # image: openstax/cnx-varnish
+    # FIXME: This image isn't ideal, but it does allow us close to the target.
+    #        See also, https://github.com/million12/docker-varnish
+    image: million12/varnish
+    links:
+      - files-server
+      - ui
+      - archive
+      - publishing
+      - press
+      - legacy-ui
+    ports:
+      - 80:80
+    volumes:
+      - .dockerfiles/cnx.vcl:/etc/varnish/cnx.vcl:z
+    environment:
+      - VCL_CONFIG=/etc/varnish/cnx.vcl
+      # - CACHE_SIZE=???
+      # - VARNISHD_PARAMS=???
+
   selenium-chrome:
     environment:
       - DISPLAY=:0
@@ -22,3 +218,12 @@ services:
     ports:
       - "5900"
     shm_size: 2g
+    links:
+      - ui
+      - proxy-openstax-org
+      # FIXME: Temporarily link raw archive without the varnish wrapper
+      - archive
+
+volumes:
+  artifacts:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
       # TODO: Load slim data via a startup script
+      - ${PWD}/cnx_slim_dump.sql.gz:/docker-entrypoint-initdb.d/cnx_slim_dump.sql.gz
     environment:
       - DB_URL=postgresql://rhaptos@/repository
       - DB_SUPER_URL=postgresql://rhaptos_admin@/repository

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -15,3 +15,7 @@ slow = mark.skipif(not config.getoption('runslow'), reason='need --runslow optio
 webview = mark.webview
 legacy = mark.legacy
 neb = mark.neb
+
+requires_deployment = mark.requires_deployment
+requires_publishing = mark.requires_publishing
+requires_varnish_routing = mark.requires_varnish_routing

--- a/tests/webview/ui/test_browse.py
+++ b/tests/webview/ui/test_browse.py
@@ -64,7 +64,7 @@ def test_click_subject_category(webview_base_url, selenium):
     browse = home.header.click_search()
 
     # WHEN a subject category is clicked
-    subject = browse.subject_list[0]
+    subject = browse.subject_list[3]
     subject_name = subject.name
     search_results = subject.click()
 

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -20,9 +20,11 @@ from pages.webview.content import Content
 @markers.test_case('C193738')
 @markers.nondestructive
 @markers.parametrize('is_archive,path,expected_response_status_code', [
-    (False, '/content/col11762', 301),
+    # FIXME Requires varnish
+    # (False, '/content/col11762', 301),
     (True, '/content/col11762', 301),
-    (False, '/content/col11762/1.10', 301),
+    # FIXME Requires varnish
+    # (False, '/content/col11762/1.10', 301),
     (True, '/content/col11762/1.10', 301),
     (False, '/contents/02040312-72c8-441e-a685-20e9333f3e1d', 200),
     (True, '/contents/02040312-72c8-441e-a685-20e9333f3e1d', 302),
@@ -159,7 +161,7 @@ def test_author_is_openstax(webview_base_url, selenium):
 @markers.nondestructive
 # https://stackoverflow.com/a/33879151
 @markers.parametrize('language', ['en', 'pl'])
-@markers.parametrize('uuid', ['d6e3aa5a-10a9-4436-9d16-ae3b1d71ac8b'])
+@markers.parametrize('uuid', ['02040312-72c8-441e-a685-20e9333f3e1d'])
 def test_derived_from_content(webview_base_url, selenium, language, uuid):
     # GIVEN the selenium driver set to a specific language and a derived book's uuid
 
@@ -172,9 +174,11 @@ def test_derived_from_content(webview_base_url, selenium, language, uuid):
     assert content_header.is_derived_from_displayed
 
     if language == 'en':
-        assert content_header.derived_from_text == 'Derived from Biology by OpenStax'
+        expected = 'Derived from Introduction to Sociology by OpenStax'
+        assert content_header.derived_from_text == expected
     elif language == 'pl':
-        assert content_header.derived_from_text == 'Utworzone z Biology autorstwa OpenStax'
+        expected = 'Utworzone z Introduction to Sociology autorstwa OpenStax'
+        assert content_header.derived_from_text == expected
 
 
 @markers.webview
@@ -250,7 +254,9 @@ def test_share_on_top_right_corner(webview_base_url, selenium):
 @markers.test_case('C132549', 'C175148')
 @markers.nondestructive
 @markers.parametrize('uuid,query,has_results,result_index,has_os_figures,has_os_tables', [
-    ('d50f6e32-0fda-46ef-a362-9bd36ca7c97d', 'table', True, 1, True, True),
+    # FIXME slim dump doesn't contain baked content:
+    #       https://github.com/openstax/quality-assurance-meta/issues/81
+    # ('d50f6e32-0fda-46ef-a362-9bd36ca7c97d', 'table', True, 1, True, True),
     ('185cbf87-c72e-48f5-b51e-f14f21b5eabd', 'mitosis genetics gorilla', False, None, None, None),
     ('185cbf87-c72e-48f5-b51e-f14f21b5eabd', 'mitosis genetics', True, 0, False, False)])
 def test_in_book_search(webview_base_url, selenium, uuid, query,
@@ -396,7 +402,7 @@ def test_section_title_for_no_markup(webview_base_url, selenium):
 @markers.webview
 @markers.test_case('C195074')
 @markers.nondestructive
-@markers.parametrize('id', ['56AW05H8@13.4:vs_mKpvU@6'])
+@markers.parametrize('id', ['u2KTPvIK@3.1:Zv6FJYpb@3'])
 def test_page_with_unicode_characters_in_title_loads(webview_base_url, selenium, id):
     # GIVEN the webview base url, the Selenium driver and the id of a page whose title has unicode
     content = Content(selenium, webview_base_url, id=id)
@@ -726,8 +732,13 @@ def test_ncy_is_not_displayed(webview_base_url, american_gov_uuid, selenium):
 @markers.nondestructive
 @markers.parametrize(
     'page_uuid,is_baked_book_index',
-    [('d50f6e32-0fda-46ef-a362-9bd36ca7c97d:72a3ef21-e30b-5ba4-9ea6-eac9699a2f09', True),
-     ('b3c1e1d2-839c-42b0-a314-e119a8aafbdd', False)]
+    [
+        # FIXME slim dump doesn't contain baked content:
+        #       https://github.com/openstax/quality-assurance-meta/issues/81
+        # ('d50f6e32-0fda-46ef-a362-9bd36ca7c97d:'
+        #  '72a3ef21-e30b-5ba4-9ea6-eac9699a2f09', True),
+        ('b3c1e1d2-839c-42b0-a314-e119a8aafbdd', False),
+    ]
 )
 def test_id_links_and_back_button(page_uuid, is_baked_book_index, webview_base_url, selenium):
     # GIVEN an index page in a baked book or a page with anchor links in an unbaked book
@@ -774,7 +785,7 @@ def test_chapter_review_version_matches_book_version(webview_base_url, selenium,
 @markers.webview
 @markers.test_case('C195064')
 @markers.nondestructive
-@markers.parametrize('ch_review_id', ['4fGVMb7P@1'])
+@markers.parametrize('ch_review_id', ['e5fbbjPE'])
 def test_books_containing_go_to_book_link(webview_base_url, selenium, ch_review_id):
     # GIVEN the webview base url, a chapter review id, and the Selenium driver
     content = ContentPage(selenium, webview_base_url, id=ch_review_id).open()
@@ -785,9 +796,9 @@ def test_books_containing_go_to_book_link(webview_base_url, selenium, ch_review_
 
     book = books[0].click_go_to_book_link
 
-    # THEN the chapter should be the very first module 1.1
+    # THEN the chapter should be the very first module 1
     assert type(book) == Content
-    assert book.chapter_section == '1.1'
+    assert book.chapter_section == '1'
     assert book.title == title
 
 

--- a/tests/webview/ui/test_content_status.py
+++ b/tests/webview/ui/test_content_status.py
@@ -8,6 +8,8 @@ from pages.webview.content_status import ContentStatus
 
 
 @markers.webview
+@markers.requires_varnish_routing
+@markers.requires_publishing
 @markers.test_case('C175149')
 @markers.nondestructive
 def test_content_status_styles(webview_base_url, selenium):

--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -15,6 +15,7 @@ _number_of_tested_books = 2
 
 
 @markers.webview
+@markers.legacy
 @markers.test_case('C167405')
 @markers.nondestructive
 @markers.parametrize('width,height', [(1024, 768), (640, 480), (480, 640)])

--- a/tests/webview/ui/test_robots.py
+++ b/tests/webview/ui/test_robots.py
@@ -8,6 +8,7 @@ from pages.robots import Robots
 
 
 @markers.webview
+@markers.requires_deployment
 @markers.test_case('C181347', 'C193737')
 @markers.nondestructive
 def test_robots(webview_base_url, archive_base_url, selenium):

--- a/tests/webview/ui/test_sitemap.py
+++ b/tests/webview/ui/test_sitemap.py
@@ -8,6 +8,7 @@ from pages.webview.sitemap_index import SitemapIndex
 
 
 @markers.webview
+@markers.requires_varnish_routing
 @markers.test_case('C205363')
 @markers.parametrize('author_username,author_name', [('Beatrice_Riviere', 'Beatrice Riviere'),
                                                      ('richb', 'Richard Baraniuk')])

--- a/tests/webview/ui/test_version.py
+++ b/tests/webview/ui/test_version.py
@@ -13,6 +13,7 @@ from pages.webview.history import History
 
 
 @markers.webview
+@markers.requires_deployment
 @markers.test_case('C175150')
 @markers.nondestructive
 def test_version(webview_base_url, selenium, github, record_property):


### PR DESCRIPTION
This uses the latest webview and cnx-archive images to test a (partial) containerized environment.

Usage at the moment is `make test-webview`, which build the local selenium container, acquires the slim dump for data and executes the tests when things are ready.

This is a bit heavy... Lift with your legs not with your back. 😛