### PR TITLE
Run travis-ci against staging.cnx.org instead of qa.cnx.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ env:
     - HEADLESS=true
     - NO_SANDBOX=true
     - PRINT_PAGE_SOURCE_ON_FAILURE=true
-    - ARCHIVE_BASE_URL=https://archive-qa.cnx.org
-    - LEGACY_BASE_URL=https://legacy-qa.cnx.org
+    - ARCHIVE_BASE_URL=https://archive-staging.cnx.org
+    - LEGACY_BASE_URL=https://legacy-staging.cnx.org
     - NEB_ENV=qa
-    - WEBVIEW_BASE_URL=https://qa.cnx.org
+    - WEBVIEW_BASE_URL=https://staging.cnx.org
   matrix:
     - MARK=webview
     - MARK=legacy RUNSLOW=true


### PR DESCRIPTION
The data is more up-to-date on staging.cnx.org.