### PR TITLE
WIP Run tests on jenkins against staging.cnx.org

### DIFF
--- a/.jenkins/testing
+++ b/.jenkins/testing
@@ -3,14 +3,14 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        sh "docker build -t openstax/cnx-automation:dev ."
+        echo 'Building ...'
+        sh 'docker build -t openstax/cnx-automation:dev .'
       }
     }
     stage('Test') {
       steps {
-        withDockerServer([uri: env.SWARM_URI, credentialsId: '']) {
-          sh "docker stack deploy --prune -c docker-compose.yml cnx-automation"
-        }
+        echo 'Testing ...'
+        sh 'make ci-test'
       }
     }
   }

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ venv:
 
 ci-test-webview:
 	docker-compose -f docker-compose.test.yml up -d
-	docker-compose -f docker-compose.test.yml exec -e ARCHIVE_BASE_URL=https://archive-staging.cnx.org -e LEGACY_BASE_URL=https://legacy-staging.cnx.org -e WEBVIEW_BASE_URL=https://staging.cnx.org -t selenium-chrome tox -- --new-first --failed-first -m "webview"
+	docker-compose -f docker-compose.test.yml exec -T -e ARCHIVE_BASE_URL=https://archive-staging.cnx.org -e LEGACY_BASE_URL=https://legacy-staging.cnx.org -e WEBVIEW_BASE_URL=https://staging.cnx.org selenium-chrome tox -- --new-first --failed-first -m "webview"
 
 ci-test: ci-test-webview ## run all ci-test-* recipes
 

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,12 @@ venv:
 		source .venv/bin/activate && \
 		pip install -r requirements.txt
 
+ci-test-webview:
+	docker-compose -f docker-compose.test.yml up -d
+	docker-compose -f docker-compose.test.yml exec -e ARCHIVE_BASE_URL=https://archive-staging.cnx.org -e LEGACY_BASE_URL=https://legacy-staging.cnx.org -e WEBVIEW_BASE_URL=https://staging.cnx.org selenium-chrome tox -- --new-first --failed-first -m "webview"
+
+ci-test: ci-test-webview ## run all ci-test-* recipes
+
 help:
 	@echo "The following targets are available"
 	@echo "clean			Remove build, test, and file artifacts"
@@ -56,3 +62,6 @@ help:
 	@echo "clean-state		Remove make's build state"
 	@echo "clean-test		Remove test artifacts"
 	@echo "test-webview		Runs the webview tests in an contained environment"
+	@echo "--------------------------------------------------------------------------------"
+	@echo "ci-test			Runs all ci-test-* make recipes"
+	@echo "ci-test-webview		Runs the webview tests in a CI environment"

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ venv:
 
 ci-test-webview:
 	docker-compose -f docker-compose.test.yml up -d
-	docker-compose -f docker-compose.test.yml exec -e ARCHIVE_BASE_URL=https://archive-staging.cnx.org -e LEGACY_BASE_URL=https://legacy-staging.cnx.org -e WEBVIEW_BASE_URL=https://staging.cnx.org selenium-chrome tox -- --new-first --failed-first -m "webview"
+	docker-compose -f docker-compose.test.yml exec -e ARCHIVE_BASE_URL=https://archive-staging.cnx.org -e LEGACY_BASE_URL=https://legacy-staging.cnx.org -e WEBVIEW_BASE_URL=https://staging.cnx.org -t selenium-chrome tox -- --new-first --failed-first -m "webview"
 
 ci-test: ci-test-webview ## run all ci-test-* recipes
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+
+  selenium-chrome:
+    image: openstax/cnx-automation:dev
+    environment:
+      - DISPLAY=:0
+      - GITHUB_TOKEN
+      - HEADLESS
+      - PRINT_PAGE_SOURCE_ON_FAILURE
+      - RUNSLOW
+      - ARCHIVE_BASE_URL
+      - LEGACY_BASE_URL
+      - LEGACY_USERNAME
+      - LEGACY_PASSWORD
+      - NEB_ENV
+      - WEBVIEW_BASE_URL
+    expose:
+      - "4444"
+    ports:
+      - "5900"
+    shm_size: 2g


### PR DESCRIPTION
This setup will run the webview tests on jenkins against staging.cnx.org.

The end result of the testing process will push the `openstax/cnx-automation:dev` image to a docker registry (e.g. hub.docker.com). This is a step in a complex workflow that later involves running this published container during test runs in application code bases. (if you have questions about the details of this plan ask me for details in the qa-team slack channel)