### PR TITLE
Fixed books_containing click read more link test

### DIFF
--- a/pages/webview/about_this_book.py
+++ b/pages/webview/about_this_book.py
@@ -1,0 +1,13 @@
+from selenium.webdriver.common.by import By
+
+from .content import Content
+
+
+class AboutBook(Content):
+
+    _about_this_book_locator = (By.CSS_SELECTOR, '.media-body-about')
+
+    @property
+    def about_this_book_section(self):
+        return self.find_element(*self._about_this_book_locator)
+

--- a/pages/webview/content_page.py
+++ b/pages/webview/content_page.py
@@ -1,5 +1,6 @@
 from selenium.webdriver.common.by import By
 
+from pages.webview.about_this_book import AboutBook
 from pages.webview.content import Content
 from regions.webview.base import Region
 from tests.utils import retry_stale_element_reference_exception
@@ -89,5 +90,5 @@ class ContentPage(Content):
             @property
             def click_go_to_book_link(self):
                 self.offscreen_click(self.find_element(*self._go_to_book_locator))
-                return Content(self.driver, self.page.base_url,
+                return AboutBook(self.driver, self.page.base_url,
                                self.page.timeout).wait_for_page_to_load()

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -9,6 +9,7 @@ from requests import get
 from time import sleep
 from datetime import datetime
 
+from pages.webview.about_this_book import AboutBook
 from pages.webview.content_page import ContentPage
 from tests import markers
 
@@ -796,9 +797,9 @@ def test_books_containing_go_to_book_link(webview_base_url, selenium, ch_review_
 
     book = books[0].click_go_to_book_link
 
-    # THEN the chapter should be the very first module 1
-    assert type(book) == Content
-    assert book.chapter_section == '1'
+    # THEN we are on the About this Book page and it is displayed
+    assert type(book) == AboutBook
+    assert book.about_this_book_section.is_displayed
     assert book.title == title
 
 


### PR DESCRIPTION
* The test was failing because they added a new "About this book" page
that shows before the preface.
* Added an `about_this_book.py` page to webview pages
* Replaced the chapter 1 assertion with
about_this_book_section.is_displayed
* Made sure to load the AboutBook page when click the go to this book
link.