### PR TITLE
Release the latest container build when tests pass for the master branch

### DIFF
--- a/.jenkins/testing
+++ b/.jenkins/testing
@@ -1,15 +1,44 @@
 pipeline {
   agent { label 'docker' }
+  environment {
+    TESTING_CONTAINER_NAME = "cnx-func-testing-${env.BUILD_ID}"
+  }
   stages {
-    stage('Build') {
+    stage('Build Dev Container') {
       steps {
         sh "docker build -t openstax/cnx-automation:dev ."
       }
     }
-    stage('Test') {
+    stage('Test Against staging.cnx.org') {
       steps {
-        withDockerServer([uri: env.SWARM_URI, credentialsId: '']) {
-          sh "docker stack deploy --prune -c docker-compose.yml cnx-automation"
+        sh "mkdir -p ${WORKSPACE}/xml-report"
+        sh "docker run -d --name ${TESTING_CONTAINER_NAME} -v ${WORKSPACE}/xml-report:/xml-report --env-file .jenkins/testing.env.list openstax/cnx-automation:dev"
+        sh "docker exec ${TESTING_CONTAINER_NAME} tox -- --new-first --failed-first -m 'webview' --junitxml=report.xml"
+      }
+      post {
+        always {
+          // Move the report to a place that is both accessible and writable
+          sh "docker exec -u root ${TESTING_CONTAINER_NAME} cp /code/report.xml /xml-report"
+          // Destroy the testing container
+          sh "docker stop ${TESTING_CONTAINER_NAME} && docker rm -f ${TESTING_CONTAINER_NAME}"
+          // Report test results
+          junit "xml-report/report.xml"
+        }
+      }
+    }
+    stage('Publish Dev Container') {
+      steps {
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker push openstax/cnx-automation:dev"
+        }
+      }
+    }
+    stage('Publish Latest Release') {
+      when { branch 'master' }
+      steps {
+        withDockerRegistry([credentialsId: 'docker-registry', url: '']) {
+          sh "docker tag openstax/cnx-automation:dev openstax/cnx-automation:latest"
+          sh "docker push openstax/cnx-automation:latest"
         }
       }
     }

--- a/.jenkins/testing.env.list
+++ b/.jenkins/testing.env.list
@@ -1,0 +1,8 @@
+DISABLE_DEV_SHM_USAGE=true
+HEADLESS=true
+NO_SANDBOX=true
+PRINT_PAGE_SOURCE_ON_FAILURE=true
+ARCHIVE_BASE_URL=https://archive-staging.cnx.org
+WEBVIEW_BASE_URL=https://staging.cnx.org
+LEGACY_BASE_URL=https://legacy-staging.cnx.org
+NEB_ENV=staging


### PR DESCRIPTION
This sets up the jenkins job to test branches as well as `master`. When `master` passes tests, it is released to the Container Registry as `openstax/cnx-automation:latest`, which then means it active for use by other `cnx-*` repos during their functional testing stages.

Ah yes... 🍹 development workflow simplified. 🏖 

