### PR TITLE
fixed id links and back button test

### DIFF
--- a/pages/webview/base.py
+++ b/pages/webview/base.py
@@ -20,7 +20,7 @@ class Page(pypom.Page):
 
     @property
     def current_url(self):
-        return self.selenium.current_url
+        return self.driver.current_url
 
     def is_element_id_displayed(self, id):
         return self.is_element_displayed(By.ID, id)

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -748,7 +748,6 @@ def test_id_links_and_back_button(page_uuid, is_baked_book_index, webview_base_u
     # THEN we end up at the linked page and the element with the same id as the link is displayed
     new_url = content_page.current_url
     assert '#' in new_url
-    assert not new_url.endswith('#')
     id = re.search('#(.+)$', new_url)[1]
     assert id
     assert content_page.is_element_id_displayed(id)

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -726,11 +726,9 @@ def test_ncy_is_not_displayed(webview_base_url, american_gov_uuid, selenium):
 @markers.parametrize(
     'page_uuid,is_baked_book_index',
     [
-        # FIXME slim dump doesn't contain baked content:
-        #       https://github.com/openstax/quality-assurance-meta/issues/81
-        # ('d50f6e32-0fda-46ef-a362-9bd36ca7c97d:'
-        #  '72a3ef21-e30b-5ba4-9ea6-eac9699a2f09', True),
-        ('b3c1e1d2-839c-42b0-a314-e119a8aafbdd', False),
+        ('d50f6e32-0fda-46ef-a362-9bd36ca7c97d:'
+         '72a3ef21-e30b-5ba4-9ea6-eac9699a2f09', True),
+        ('6a0568d8-23d7-439b-9a01-16e4e73886b3', False),
     ]
 )
 def test_id_links_and_back_button(page_uuid, is_baked_book_index, webview_base_url, selenium):
@@ -752,6 +750,7 @@ def test_id_links_and_back_button(page_uuid, is_baked_book_index, webview_base_u
     assert '#' in new_url
     assert not new_url.endswith('#')
     id = re.search('#(.+)$', new_url)[1]
+    assert id
     assert content_page.is_element_id_displayed(id)
 
     # WHEN we click the browser's back button


### PR DESCRIPTION
* Changed the page to visit for checking anchor links.
* Fixed deprecation message on base page about using self.selenium
instead of self.driver.
* Removed assert for `#` in `new_url` to an assert on the id returned by the re.search.