### PR TITLE
Fix jenkins testing container name uniqueness

### DIFF
--- a/.jenkins/testing
+++ b/.jenkins/testing
@@ -1,7 +1,9 @@
+@Library('pipeline-library') _
+
 pipeline {
   agent { label 'docker' }
   environment {
-    TESTING_CONTAINER_NAME = "cnx-func-testing-${env.BUILD_NUMBER}-${env.BUILD_ID}"
+    TESTING_CONTAINER_NAME = meta.containerName()
   }
   stages {
     stage('Build Dev Container') {
@@ -11,16 +13,16 @@ pipeline {
     }
     stage('Test Against staging.cnx.org') {
       steps {
-        sh "mkdir -p ${WORKSPACE}/xml-report"
-        sh "docker run -d --name ${TESTING_CONTAINER_NAME} -v ${WORKSPACE}/xml-report:/xml-report --env-file .jenkins/testing.env.list openstax/cnx-automation:dev"
-        sh "docker exec ${TESTING_CONTAINER_NAME} tox -- --new-first --failed-first -m 'webview' --junitxml=report.xml"
+        sh "mkdir -p ${env.WORKSPACE}/xml-report"
+        sh "docker run -d --name ${env.TESTING_CONTAINER_NAME} -v ${env.WORKSPACE}/xml-report:/xml-report --env-file .jenkins/testing.env.list openstax/cnx-automation:dev"
+        sh "docker exec ${env.TESTING_CONTAINER_NAME} tox -- --new-first --failed-first -m 'webview' --junitxml=report.xml"
       }
       post {
         always {
           // Move the report to a place that is both accessible and writable
-          sh "docker exec -u root ${TESTING_CONTAINER_NAME} cp /code/report.xml /xml-report"
+          sh "docker exec -u root ${env.TESTING_CONTAINER_NAME} cp /code/report.xml /xml-report"
           // Destroy the testing container
-          sh "docker stop ${TESTING_CONTAINER_NAME} && docker rm -f ${TESTING_CONTAINER_NAME}"
+          sh "docker stop ${env.TESTING_CONTAINER_NAME} && docker rm -f ${env.TESTING_CONTAINER_NAME}"
           // Report test results
           junit "xml-report/report.xml"
         }


### PR DESCRIPTION
This is a quick fix to ensure the container name is unique.
Instead of using a generic name and incremental build number,
use the job name with the incremental build number