### PR TITLE
Fixed test_get_this_book button by removing epub option

### DIFF
--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -567,10 +567,6 @@ class Content(Page):
             By.XPATH,
             ".//div[contains(@class, 'download-book')]//ul//li//a[text()='PDF']",
         )
-        _epub_link_locator = (
-            By.XPATH,
-            ".//div[contains(@class, 'download-book')]//ul//li//a[text()='EPUB']",
-        )
         _offline_zip_link_locator = (
             By.XPATH,
             ".//div[contains(@class, 'download-book')]//ul//li//a[text()='Offline ZIP']",
@@ -624,10 +620,6 @@ class Content(Page):
         @property
         def is_pdf_link_displayed(self):
             return self.is_element_present(*self._pdf_link_locator)
-
-        @property
-        def is_epub_link_displayed(self):
-            return self.is_element_present(*self._epub_link_locator)
 
         @property
         def is_offline_zip_link_displayed(self):

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -434,7 +434,6 @@ def test_get_this_book(webview_base_url, selenium):
     if button_displayed:
         get_this_book = content.click_get_this_book_button()
         pdf_displayed = get_this_book.is_pdf_link_displayed
-        epub_displayed = get_this_book.is_epub_link_displayed
         offline_zip_displayed = get_this_book.is_offline_zip_link_displayed
 
     # THEN links to download the pdf, epub and offline zip versions are displayed
@@ -444,10 +443,15 @@ def test_get_this_book(webview_base_url, selenium):
     if not button_displayed:
         assert not downloads.is_any_available
         pytest.skip('No files available to download: "Get This Book!" button not present.')
+    else:
+        assert pdf_displayed or offline_zip_displayed
 
-    assert pdf_displayed == downloads.is_pdf_available
-    assert epub_displayed == downloads.is_epub_available
-    assert offline_zip_displayed == downloads.is_offline_zip_available
+    # Check the footer
+    if pdf_displayed:
+        assert downloads.is_pdf_available
+
+    if offline_zip_displayed:
+        assert downloads.is_offline_zip_available
 
 
 @markers.webview


### PR DESCRIPTION
* Removed epub assertions from tests and locators from page object.
* Refactored the tests to look for either PDF or the offline zip and the
footer if they exist.