### PR TITLE
Fixed test_navigation by checking for introduction first

### DIFF
--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -135,7 +135,7 @@ class Content(Page):
     @property
     @retry_stale_element_reference_exception
     def section_title(self):
-        return self.section_title_div.text.replace(self.chapter_section, "").lstrip()
+        return self.section_title_div.text
 
     @property
     @retry_stale_element_reference_exception

--- a/regions/webview/content_item.py
+++ b/regions/webview/content_item.py
@@ -8,7 +8,7 @@ from regions.webview.base import Region
 
 
 class ContentItem(Region):
-    _chapter_section_span_locator = (By.CSS_SELECTOR, "span.chapter-number")
+    _chapter_section_span_locator = (By.CSS_SELECTOR, "span.os-number")
     _title_span_locator = (By.CSS_SELECTOR, "span.title")
 
     def __init__(self, page, parent_root, index):

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -743,7 +743,8 @@ def test_navigation(webview_base_url, selenium):
     num_pages = toc.number_of_pages
 
     assert type(content) == Content
-    assert content.chapter_section == "1"
+    # Introduction should be the first section loaded
+    assert content.section_title == "Introduction"
     # Preface is skipped by default
     assert header_nav.progress_bar_fraction_is(2 / num_pages)
 


### PR DESCRIPTION
* Changed the beginning of the test to look for introduction rather than section number 1.
* Updated the section title so it doesn't strip out the section number
* Updated chapter_section_span locator to the new locator of `os-number`