### PR TITLE
Fixed test_title_link_loads_correct_page test by making titles lowercase

### DIFF
--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -194,7 +194,7 @@ def test_title_link_loads_correct_page(webview_base_url, selenium):
     content = book.click_title_link()
     content_title = content.clean_title
 
-    title_ratio = similar(book_title, content_title)
+    title_ratio = similar(book_title.lower(), content_title.lower())
 
     # THEN compare the title from the home page and the content page for exact-ness.
     assert book_title == content_title or title_ratio >= sim_ratio


### PR DESCRIPTION
This test would fail randomly b/c of a book title that was changed to be
all uppercase. This causes the similarity ratio to be too low and fails
the test. The solution is to force the titles to be lowercase before
their similarity ratio is calculated.

* Updated the test_title_link_loads_correct_page test by having the
titles be lowercase before being passed into the similar function.