### PR TITLE
marking publishing test as xfail due to possible bug

### DIFF
--- a/tests/legacy/ui/test_create_import_publish_module_and_collection.py
+++ b/tests/legacy/ui/test_create_import_publish_module_and_collection.py
@@ -73,8 +73,8 @@ class TestCreateImportPublishModuleAndCollection(object):
         assert module_edit.title == "CNX Automation Test Module"
         assert not module_edit.is_blank
 
-    @markers.xfail(reason="https://github.com/openstax/cnx/issues/220")
     @markers.legacy
+    @markers.xfail(reason="https://github.com/openstax/cnx/issues/220")
     @markers.slow
     def test_publish_module(
         self,

--- a/tests/legacy/ui/test_create_import_publish_module_and_collection.py
+++ b/tests/legacy/ui/test_create_import_publish_module_and_collection.py
@@ -73,6 +73,7 @@ class TestCreateImportPublishModuleAndCollection(object):
         assert module_edit.title == "CNX Automation Test Module"
         assert not module_edit.is_blank
 
+    @markers.xfail(reason="https://github.com/openstax/cnx/issues/220")
     @markers.legacy
     @markers.slow
     def test_publish_module(


### PR DESCRIPTION
Marking legacy publishing test as xfail due to possible bug.

https://github.com/openstax/cnx/issues/220