### PR TITLE
Fixed test_in_book_search by using full title

### DIFF
--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -529,10 +529,6 @@ class Content(Page):
                 return self.title_span.text
 
             @property
-            def title_with_chapter_section(self):
-                return "{0} {1}".format(self.chapter_section, self.title)
-
-            @property
             def content_q(self):
                 return self.link.find_element(*self._content_q_locator)
 

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -319,7 +319,7 @@ def test_share_on_top_right_corner(webview_base_url, selenium):
             None,
             None,
         ),
-        ("185cbf87-c72e-48f5-b51e-f14f21b5eabd", "mitosis genetics", True, 0, False, False),
+        ("185cbf87-c72e-48f5-b51e-f14f21b5eabd", "mitosis genetics", True, 0, True, False),
     ],
 )
 def test_in_book_search(
@@ -355,7 +355,7 @@ def test_in_book_search(
             assert result.count_occurrences(word) == result.count_bold_occurrences(word)
 
     result = results[result_index]
-    title = result.title_with_chapter_section
+    title = result.title
     content = result.click_link()
     assert content.section_title == title
 


### PR DESCRIPTION
* The result.title_with_chapter_section was returning the section
number twice. It looks like we no longer need to format that and we can
go with the title.
* The search result now has figures so this was made to true.