### PR TITLE
Comment about where this base image comes from

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# See https://github.com/openstax/docker-qa for more information about this base image.
 FROM openstax/selenium-chrome-debug:latest
 
 USER root


### PR DESCRIPTION
It's not exactly clear that openstax/selenium-chrome-debug comes from the openstax/docker-qa repo. This just points that out.