### PR TITLE
Changes to cnx-automation test files: test_browse.py and test_content…

### DIFF
--- a/pages/webview/content.py
+++ b/pages/webview/content.py
@@ -281,6 +281,7 @@ class Content(Page):
             _root_locator = (By.CSS_SELECTOR, "#content div.pinnable div.share")
             _facebook_share_link_locator = (By.CSS_SELECTOR, "ul li a.facebook")
             _twitter_share_link_locator = (By.CSS_SELECTOR, "ul li a.twitter")
+            _linkedin_share_link_locator = (By.CSS_SELECTOR, "ul li a.linkedin")
 
             @property
             def is_facebook_share_link_displayed(self):
@@ -305,6 +306,18 @@ class Content(Page):
             @property
             def twitter_share_url(self):
                 return self.twitter_share_link.get_attribute("href")
+
+            @property
+            def is_linkedin_share_link_displayed(self):
+                return self.is_element_displayed(*self._linkedin_share_link_locator)
+
+            @property
+            def linkedin_share_link(self):
+                return self.find_element(*self._linkedin_share_link_locator)
+
+            @property
+            def linkedin_share_url(self):
+                return self.linkedin_share_link.get_attribute("href")
 
         class HeaderNav(Region):
             _root_locator = (By.CSS_SELECTOR, "div.media-nav")

--- a/tests/webview/ui/test_browse.py
+++ b/tests/webview/ui/test_browse.py
@@ -8,9 +8,6 @@ from pages.webview.home import Home
 from pages.webview.search_results import SearchResults
 
 
-# !!! "C176268" - removed this test case from this function's @markers.test_case(...)
-# and added to the one below - "def test_subject_categories_load(webview_base_url, selenium):"
-
 @markers.webview
 @markers.test_case("C176269")
 @markers.nondestructive
@@ -26,9 +23,6 @@ def test_search_input_and_button_are_displayed(webview_base_url, selenium):
     assert browse_page.is_search_input_displayed
     assert browse_page.is_advanced_search_link_displayed
 
-
-# !!! "C176270" - this is a non-existent test case. Instead, C176268 test case verifies this.
-# Replacing "C176270" with C176268
 
 @markers.webview
 @markers.smoke

--- a/tests/webview/ui/test_browse.py
+++ b/tests/webview/ui/test_browse.py
@@ -8,8 +8,11 @@ from pages.webview.home import Home
 from pages.webview.search_results import SearchResults
 
 
+# !!! "C176268" - removed this test case from this function's @markers.test_case(...)
+# and added to the one below - "def test_subject_categories_load(webview_base_url, selenium):"
+
 @markers.webview
-@markers.test_case("C176268", "C176269")
+@markers.test_case("C176269")
 @markers.nondestructive
 def test_search_input_and_button_are_displayed(webview_base_url, selenium):
     # GIVEN the webview base url and Selenium driver
@@ -24,9 +27,12 @@ def test_search_input_and_button_are_displayed(webview_base_url, selenium):
     assert browse_page.is_advanced_search_link_displayed
 
 
+# !!! "C176270" - this is a non-existent test case. Instead, C176268 test case verifies this.
+# Replacing "C176270" with C176268
+
 @markers.webview
 @markers.smoke
-@markers.test_case("C176270")
+@markers.test_case("C176268")
 @markers.nondestructive
 def test_subject_categories_load(webview_base_url, selenium):
     # GIVEN the webview base url and Selenium driver

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -141,7 +141,6 @@ def test_canonical_link_is_correct(webview_base_url, selenium, id):
     assert content.section_title in section_title
 
 
-# !!! "C176231" - non-existent test case. Removed it from the @markers.test_case(...)
 @markers.webview
 @markers.test_case("C176232", "C176233")
 @markers.nondestructive
@@ -373,9 +372,6 @@ def test_in_book_search(
     for table in content_region.os_tables:
         assert table.caption.is_labeled
         assert table.caption.is_numbered
-
-
-# !!! "C176260" - outdated (no google+ in cnx). Removed it from the @markers.test_case(...)
 
 
 @markers.webview
@@ -793,8 +789,6 @@ def test_ncy_is_not_displayed(webview_base_url, american_gov_uuid, selenium):
     assert page.is_ncy_displayed is False
 
 
-# !!! "C162195" - very old bug, not present in trello anymore. Removed it from @markers.test_case(...)
-# Also, it is verified in test case C132548
 @markers.webview
 @markers.test_case("C132547", "C132548")
 @markers.nondestructive

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -377,6 +377,7 @@ def test_in_book_search(
 
 # !!! "C176260" - outdated (no google+ in cnx). Removed it from the @markers.test_case(...)
 
+
 @markers.webview
 @markers.otto
 @markers.smoke
@@ -403,7 +404,9 @@ def test_share_links_displayed(webview_base_url, selenium):
     )
     assert share.twitter_share_url == expected_twitter_url
 
-    expected_linkedin_url = "https://www.linkedin.com/shareArticle?mini=true&url={url}&title={title}&summary=An%20OpenStax%20CNX%20book&source=OpenStax%20CNX".format(url=current_url, title=normalized_title)
+    expected_linkedin_url = "https://www.linkedin.com/shareArticle?mini=true&url={url}&title={title}&summary=An%20OpenStax%20CNX%20book&source=OpenStax%20CNX".format(
+        url=current_url, title=normalized_title
+    )
     assert share.linkedin_share_url == expected_linkedin_url
 
 
@@ -458,23 +461,6 @@ def test_get_this_book(webview_base_url, selenium):
 
     if offline_zip_displayed:
         assert downloads.is_offline_zip_available
-
-# !!! old bug verification from March 2017. Test case was selected to be deleted. We should remove the whole function
-# @markers.webview
-# @markers.test_case("C167408")
-# @markers.nondestructive
-# def test_section_title_for_no_markup(webview_base_url, selenium):
-#     # GIVEN the home page and a book
-#     home = Home(selenium, webview_base_url).open()
-#     book = home.featured_books.openstax_list[0]
-
-#     # WHEN the book's cover is clicked
-#     content = book.click_book_cover()
-
-#     # THEN the section title does not contain HTML markup
-#     section_title = content.section_title
-#     assert "<" not in section_title
-#     assert ">" not in section_title
 
 
 @markers.webview

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -378,6 +378,7 @@ def test_in_book_search(
 # !!! "C176260" - outdated (no google+ in cnx). Removed it from the @markers.test_case(...)
 
 @markers.webview
+@markers.otto
 @markers.smoke
 @markers.test_case("C176258", "C176259", "C176261")
 @markers.nondestructive
@@ -402,7 +403,7 @@ def test_share_links_displayed(webview_base_url, selenium):
     )
     assert share.twitter_share_url == expected_twitter_url
 
-    expected_linkedin_url = "https://www.linkedin.com/sharing/".format(url=current_url)
+    expected_linkedin_url = "https://www.linkedin.com/shareArticle?mini=true&url={url}&title={title}&summary=An%20OpenStax%20CNX%20book&source=OpenStax%20CNX".format(url=current_url, title=normalized_title)
     assert share.linkedin_share_url == expected_linkedin_url
 
 

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -402,6 +402,9 @@ def test_share_links_displayed(webview_base_url, selenium):
     )
     assert share.twitter_share_url == expected_twitter_url
 
+    expected_linkedin_url = "https://www.linkedin.com/sharing/".format(url=current_url)
+    assert share.linkedin_share_url == expected_linkedin_url
+
 
 @markers.webview
 @markers.test_case("C193880")

--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -141,8 +141,9 @@ def test_canonical_link_is_correct(webview_base_url, selenium, id):
     assert content.section_title in section_title
 
 
+# !!! "C176231" - non-existent test case. Removed it from the @markers.test_case(...)
 @markers.webview
-@markers.test_case("C176231", "C176232", "C176233")
+@markers.test_case("C176232", "C176233")
 @markers.nondestructive
 def test_navs_and_elements_are_displayed(webview_base_url, selenium):
     # GIVEN the home page
@@ -374,9 +375,11 @@ def test_in_book_search(
         assert table.caption.is_numbered
 
 
+# !!! "C176260" - outdated (no google+ in cnx). Removed it from the @markers.test_case(...)
+
 @markers.webview
 @markers.smoke
-@markers.test_case("C176258", "C176259", "C176260", "C176261")
+@markers.test_case("C176258", "C176259", "C176261")
 @markers.nondestructive
 def test_share_links_displayed(webview_base_url, selenium):
     # GIVEN the home page
@@ -452,22 +455,22 @@ def test_get_this_book(webview_base_url, selenium):
     if offline_zip_displayed:
         assert downloads.is_offline_zip_available
 
+# !!! old bug verification from March 2017. Test case was selected to be deleted. We should remove the whole function
+# @markers.webview
+# @markers.test_case("C167408")
+# @markers.nondestructive
+# def test_section_title_for_no_markup(webview_base_url, selenium):
+#     # GIVEN the home page and a book
+#     home = Home(selenium, webview_base_url).open()
+#     book = home.featured_books.openstax_list[0]
 
-@markers.webview
-@markers.test_case("C167408")
-@markers.nondestructive
-def test_section_title_for_no_markup(webview_base_url, selenium):
-    # GIVEN the home page and a book
-    home = Home(selenium, webview_base_url).open()
-    book = home.featured_books.openstax_list[0]
+#     # WHEN the book's cover is clicked
+#     content = book.click_book_cover()
 
-    # WHEN the book's cover is clicked
-    content = book.click_book_cover()
-
-    # THEN the section title does not contain HTML markup
-    section_title = content.section_title
-    assert "<" not in section_title
-    assert ">" not in section_title
+#     # THEN the section title does not contain HTML markup
+#     section_title = content.section_title
+#     assert "<" not in section_title
+#     assert ">" not in section_title
 
 
 @markers.webview
@@ -800,8 +803,10 @@ def test_ncy_is_not_displayed(webview_base_url, american_gov_uuid, selenium):
     assert page.is_ncy_displayed is False
 
 
+# !!! "C162195" - very old bug, not present in trello anymore. Removed it from @markers.test_case(...)
+# Also, it is verified in test case C132548
 @markers.webview
-@markers.test_case("C132547", "C132548", "C162195")
+@markers.test_case("C132547", "C132548")
 @markers.nondestructive
 @markers.parametrize(
     "page_uuid,is_baked_book_index",


### PR DESCRIPTION
Latest changes:

test_content.py
"C176231" - non-existent test case. Removed it from the @markers.test_case(...)
"C176260" - outdated (no google+ in cnx). Removed it from the @markers.test_case(...)
"C162195" - very old bug, not present in trello anymore. Removed it from @markers.test_case(...)
Also, it is verified in test case C132548

test_browse.py
"C176268" - removed this test case from this function's @markers.test_case(...)
and added to the one below - "def test_subject_categories_load(webview_base_url, selenium):"
"C176270" - this is a non-existent test case. Instead, C176268 test case verifies this.
Replacing "C176270" with C176268

….py, removing/changing test cases in markers in 
test_browse.py
test_content.py 

Added notes to both test cases to affected functions. 