### PR TITLE
Fixed test_title_link_loads_correct_page intermittent failure due to rex redirect

### DIFF
--- a/tests/webview/ui/test_home.py
+++ b/tests/webview/ui/test_home.py
@@ -181,7 +181,7 @@ def test_book_cover_loads_correct_page(webview_base_url, selenium, rex_released_
 @markers.webview
 @markers.test_case("C176229")
 @markers.nondestructive
-def test_title_link_loads_correct_page(webview_base_url, selenium):
+def test_title_link_loads_correct_page(webview_base_url, selenium, rex_released_books):
     # GIVEN the webview base url, the Selenium driver, and a similarity ratio
     sim_ratio = 0.4
 
@@ -192,7 +192,11 @@ def test_title_link_loads_correct_page(webview_base_url, selenium):
     # AND we have a similarity ratio of the title
 
     home = Home(selenium, webview_base_url).open()
-    book = home.featured_books.get_random_openstax_book()
+
+    while True:
+        book = home.featured_books.get_random_openstax_book()
+        if book.cnx_id not in rex_released_books:
+            break
 
     book_title = book.clean_title
     content = book.click_title_link()


### PR DESCRIPTION
Test would fail intermittently b/c a random book is being selected and
that random book could be a released rex book which would cause
timeouts. Problem corrected by continuously selecting random books until
a non-rex book is found.