### PR TITLE
test_redirecting_to_rex_from_within_webview: changed marker from webview to rex

### DIFF
--- a/tests/webview/integration/test_rex_redirects.py
+++ b/tests/webview/integration/test_rex_redirects.py
@@ -27,7 +27,7 @@ def test_archive_is_still_reachable(archive_base_url, rex_base_url):
         assert rex_base_url not in hist.headers["location"]
 
 
-@markers.webview
+@markers.rex
 @markers.test_case("C553080")
 @markers.nondestructive
 def test_redirecting_to_rex_from_within_webview(


### PR DESCRIPTION
function 'test_redirecting_to_rex_from_within_webview' had an incorrect marker webview. changed it to rex.