### PR TITLE
readding two test files as they were somehow deleted 

### DIFF
--- a/tests/webview/integration/test_rex_redirects.py
+++ b/tests/webview/integration/test_rex_redirects.py
@@ -62,7 +62,7 @@ def test_redirecting_to_rex_from_within_webview(
 @markers.rex
 @markers.nondestructive
 def test_minimal_view_for_android_apps(webview_base_url, rex_base_url):
-    """All requests for REX books that come from the Android App
+    """ All requests for REX books that come from the Android App
     should continue to pass through to the cnx site (these requests
     are indicated by the attachment of the query-string: `?minimal=true`)
     https://github.com/openstax/cnx/issues/401

--- a/tests/webview/integration/test_webview_integration.py
+++ b/tests/webview/integration/test_webview_integration.py
@@ -8,7 +8,7 @@ from tests import markers
 @markers.parametrize("uuid, version", [("fea3130c-6e57-41b2-a00f-0267ffae273c", 5)])
 def test_archive_redirect_for_google_results(archive_base_url, uuid, version):
     # end-to-end integration test for redirecting google away from archive URLs
-    # see: https://github.com/openstax/cnx/issues/209
+    # see issue: https://github.com/openstax/cnx/issues/209
 
     # GIVEN an "archive" URL
     url = f"{archive_base_url}/contents/{uuid}@{version}"


### PR DESCRIPTION
Somehow I deleted these 2 files on the redirects_as_301 branch which I just merged to master. Never noticed this and now these 2 files are missing on master. I am readding them here. No changes just minor changes in the comments of both files to trigger change.
