### PR TITLE
add test that archive redirects respect host header

### DIFF
--- a/tests/archive/integration/test_redirects.py
+++ b/tests/archive/integration/test_redirects.py
@@ -6,12 +6,13 @@ from tests import markers
 @markers.archive
 @markers.nondestructive
 @markers.parametrize("uuid", [("fea3130c-6e57-41b2-a00f-0267ffae273c")])
-def test_host_header_redirect(archive_base_url, uuid):
-    # GIVEN an "archive" URL
+def test_location_header_applied_to_redirect(archive_base_url, uuid):
+    # GIVEN an "archive" URL and Host Header
     url = f"{archive_base_url}/contents/{uuid}"
+    headers = {"Host": "openstax.org"}
 
     # WHEN a web request has a host
-    response = requests.get(url=url, headers={"Host": "openstax.org"}, allow_redirects=False)
+    response = requests.get(url=url, headers=headers, allow_redirects=False)
 
-    # THEN the host is used in the redirect
-    assert "openstax.org" in response.headers["Location"]
+    # THEN the host value is used in the Location header of the redirect
+    assert headers["Host"] in response.headers["Location"]

--- a/tests/archive/integration/test_redirects.py
+++ b/tests/archive/integration/test_redirects.py
@@ -2,14 +2,16 @@ import requests
 
 from tests import markers
 
+
+@markers.archive
 @markers.nondestructive
 @markers.parametrize("uuid", [("fea3130c-6e57-41b2-a00f-0267ffae273c")])
-def test_archive_redirect(archive_base_url, uuid):
+def test_host_header_redirect(archive_base_url, uuid):
     # GIVEN an "archive" URL
     url = f"{archive_base_url}/contents/{uuid}"
 
     # WHEN a web request has a host
     response = requests.get(url=url, headers={"Host": "openstax.org"}, allow_redirects=False)
 
-    # THEN the host is used in the redirect 
+    # THEN the host is used in the redirect
     assert "openstax.org" in response.headers["Location"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ def get_custom_markers():
         "requires_deployment: mark tests that require deployment",
         "vendor: mark tests that target vendor.cnx.org",
         "awss3: mark tests that target collections in aws s3 bucket",
+        "archive: mark tests that target archive",
     )
 
 

--- a/tests/markers.py
+++ b/tests/markers.py
@@ -23,6 +23,7 @@ legacy = mark.legacy
 neb = mark.neb
 rex = mark.rex
 awss3 = mark.awss3
+archive = mark.archive
 
 requires_complete_dataset = mark.requires_complete_dataset
 requires_deployment = mark.requires_deployment

--- a/tests/webview/integration/test_archive_redirects.py
+++ b/tests/webview/integration/test_archive_redirects.py
@@ -1,0 +1,15 @@
+import requests
+
+from tests import markers
+
+@markers.nondestructive
+@markers.parametrize("uuid", [("fea3130c-6e57-41b2-a00f-0267ffae273c")])
+def test_archive_redirect(archive_base_url, uuid):
+    # GIVEN an "archive" URL
+    url = f"{archive_base_url}/contents/{uuid}"
+
+    # WHEN a web request has a host
+    response = requests.get(url=url, headers={"Host": "openstax.org"}, allow_redirects=False)
+
+    # THEN the host is used in the redirect 
+    assert "openstax.org" in response.headers["Location"]


### PR DESCRIPTION
Test should run in cnx-automation by using:

```shell
pytest -m archive --webview-base-url https://qa.cnx.org --legacy-base-url https://legacy-qa.cnx.org --archive-base-url https://archive-qa.cnx.org
```