### PR TITLE
fixing hanging collection id in test_content

### DIFF
--- a/tests/webview/ui/test_content.py
+++ b/tests/webview/ui/test_content.py
@@ -788,7 +788,7 @@ def test_id_links_and_back_button(page_uuid, is_baked_book_index, webview_base_u
 @markers.webview
 @markers.test_case("C181754")
 @markers.nondestructive
-@markers.parametrize("ch_review_id", ["u2KTPvIK@3.32:6IrsWVCW", pytest.param("u2KTPvIK:6IrsWVCW")])
+@markers.parametrize("ch_review_id", ["u2KTPvIK@3.32:6IrsWVCW", pytest.param("TqqPA4io:_LheuYk4")])
 def test_chapter_review_version_matches_book_version(webview_base_url, selenium, ch_review_id):
     # GIVEN the webview base url, a chapter review id, and the Selenium driver
 


### PR DESCRIPTION
previous collection:page short ids failed and remained hanging. changed it to 
pytest.param("TqqPA4io:_LheuYk4") in
test_content:test_chapter_review_version_matches_book_version