### PR TITLE
added fixtures for code_tag and queue_state_bucket_name

### DIFF
--- a/fixtures/webview.py
+++ b/fixtures/webview.py
@@ -623,3 +623,25 @@ def aws_secret_access_key_value(request):
     awssecretvalue = config.getoption("aws_secret_access_key_value")
     if awssecretvalue is not None:
         return awssecretvalue
+
+
+@pytest.fixture
+def code_tag(request):
+    """Return a deployment code tag"""
+    config = request.config
+    code_tag = config.getoption("code_tag") or config.getini("code_tag")
+    if code_tag is not None:
+        skip_if_destructive_and_sensitive(request, code_tag)
+        return code_tag
+
+
+@pytest.fixture
+def queue_state_bucket(request):
+    """Return queue state bucket name"""
+    config = request.config
+    queue_state_bucket = config.getoption("queue_state_bucket") or config.getini(
+        "queue_state_bucket"
+    )
+    if queue_state_bucket is not None:
+        skip_if_destructive_and_sensitive(request, queue_state_bucket)
+        return queue_state_bucket

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -138,6 +138,20 @@ def pytest_addoption(parser):
         default=os.getenv("S3_BASE_URL", None),
         help="base url for cnx books in aws s3 bucket.",
     )
+    parser.addini("code_tag", help="code tag for latest deployment in s3 bucket.")
+    parser.addoption(
+        "--code_tag",
+        metavar="tag",
+        default=os.getenv("CODE_TAG", None),
+        help="code tag for latest deployment in s3 bucket.",
+    )
+    parser.addini("queue_state_bucket", help="s3 queue state bucket name.")
+    parser.addoption(
+        "--queue_state_bucket",
+        metavar="name",
+        default=os.getenv("QUEUE_STATE_BUCKET", None),
+        help="s3 queue state bucket name.",
+    )
     parser.addoption(
         "--legacy_username", default=os.getenv("LEGACY_USERNAME"), help="username for CNX legacy."
     )

--- a/tests/s3_bucket/test_s3_pages_content.py
+++ b/tests/s3_bucket/test_s3_pages_content.py
@@ -8,30 +8,44 @@ from urllib.error import HTTPError
 
 import requests
 import os
+
 import boto3
 
 """
 Verifies collections in the aws s3 bucket against queue-state list of approved books
-Latest update on Aug. 11th, 2020
+Latest update on Sept. 9th, 2020
 """
 
 
-def test_create_queue_state_books_list(aws_access_key_id_value, aws_secret_access_key_value):
+def test_create_queue_state_books_list(
+    aws_access_key_id_value, aws_secret_access_key_value, code_tag, queue_state_bucket
+):
 
-    # Ripal's code: creates a json file of approved books containing these details:
+    # Ripal's code: creates a json file of approved books from queue-state list containing these details:
     # collection_id, style, version, server, uuid
-    # from queue-state list
 
+    # apply aws credentials to access s3 buckets
     os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id_value
     os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key_value
 
-    s3_queue_state_bucket = "sandbox-web-hosting-content-queue-state"
+    client = boto3.client("s3")
+
+    # queue state bucket containing approved books list with their corresponding states. Can be applied by
+    # --state_bucket bucket-name
+    # staging/sandbox environment "openstax-sandbox-web-hosting-content-queue-state"
+    # production environment "openstax-web-hosting-content-queue-state"
+    s3_queue_state_bucket = queue_state_bucket
+
+    # code tag of each new deployment in s3 bucket. Can be applied by --code_tag code.number
+    code_tag = code_tag
+
+    # queue filename set in the bakery environment, same for both staging and production
     queue_filename = "distribution-queue.json"
-    code_tag = "20200708.184941"
+
     json_output_filename = f"{os.getcwd()}/fixtures/data/webview/s3_bucket_books.json"
 
     s3_bucket_books = []
-    client = boto3.client("s3")
+
     queue_state_key = f"{code_tag}.{queue_filename}"
 
     resp = client.list_object_versions(Bucket=s3_queue_state_bucket, Prefix=queue_state_key)


### PR DESCRIPTION
s3 bucket book verification: added fixtures for code_tag and queue_state_bucket_name, so when they change, we can supply them as command lines via pytest