### PR TITLE
adjusting the s3 bucket fixture code as per Ripal's comment

### DIFF
--- a/fixtures/bucket_books_tree.py
+++ b/fixtures/bucket_books_tree.py
@@ -8,7 +8,7 @@ from urllib.error import HTTPError
 
 """
 Returns the content tree of each collection in aws s3 bucket
-Latest update on Oct. 7th, 2020
+Latest update on Oct. 14th, 2020
 """
 
 
@@ -37,26 +37,20 @@ def bucket_books_tree(s3_base_url, code_tag, s3_queue_state_bucket_books):
     ]
 
     # list of approved book urls without http errors
-    approved_books_full_url_modified = []
-
-    for ublu in approved_books_full_url:
-
-        try:
-            urllib.request.urlopen(ublu)
-        except HTTPError as h_e:
-            # Return code 404, 501, ...
-            print("HTTPError (check concourse jobs): {}".format(h_e.code) + ", " + ublu)
-        else:
-            # Return code 200
-            approved_books_full_url_modified.append(ublu)
-
     book_tree = []
 
-    for books in range(len(approved_books_full_url_modified)):
+    for books in approved_books_full_url:
 
-        s3_books = urllib.request.urlopen(approved_books_full_url_modified[books]).read()
-        s3_jdata = json.loads(s3_books)
-        book_tree.append(s3_jdata["tree"])
-        continue
+        try:
+            urllib.request.urlopen(books)
+        except HTTPError as h_e:
+            # Return code 404, 501, ...
+            print("HTTPError (check concourse jobs): {}".format(h_e.code) + ", " + books)
+        else:
+            # Return code 200
+            s3_books = urllib.request.urlopen(books).read()
+            s3_jdata = json.loads(s3_books)
+            book_tree.append(s3_jdata["tree"])
+            continue
 
     return book_tree


### PR DESCRIPTION
removed and consolidated the code as per this comment in other PR:

 I believe you can insert the results into book_tree in the try block while iterating on approved_books_full_url instead of using approved_books_full_url_modified as an intermediate list you iterate on in a second pass.