### PR TITLE
Dockerfile: changing chrome-debug version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See https://github.com/openstax/docker-qa for more information about this base image.
-FROM openstax/selenium-chrome-debug:3.141.59
+FROM openstax/selenium-chrome-debug:latest
 
 USER root
 


### PR DESCRIPTION
we did this small change a long time ago with Mike, to get selenium-chrome-debug version latest and not a fixed version
I never pushed the change to master