### PR TITLE
test to verify collection.xml files in content repos

### DIFF
--- a/tests/s3_bucket/test_github_content_collections.py
+++ b/tests/s3_bucket/test_github_content_collections.py
@@ -1,0 +1,44 @@
+import json
+import urllib
+import urllib.error
+import urllib.parse
+import urllib.request
+
+"""
+Verifies content of collection.xml of every collection in github content repo.
+Latest update on March. 23nd, 2021
+"""
+
+
+def test_github_content_collections(git_content_repos, headers_data):
+
+    for repo in git_content_repos:
+
+        collections_dir = f"https://api.github.com/repos/openstax/{repo}/contents/collections/"
+
+        collections_req = urllib.request.Request(collections_dir, headers=headers_data)
+        collections_list = urllib.request.urlopen(collections_req).read()
+
+        for item in json.loads(collections_list):
+
+            if item["type"] != "file":
+
+                # Ignore anything that may not be a file
+                continue
+
+            rel_path = item["path"]
+            collections_url = f"https://api.github.com/repos/openstax/{repo}/contents/{rel_path}"
+
+            collections_req = urllib.request.Request(collections_url, headers=headers_data)
+            collections_resp = urllib.request.urlopen(collections_req)
+
+            if collections_resp.status != 200:
+                assert (
+                    collections_resp.status != 200
+                ), f"FAILED to find collection.xml in {rel_path}"
+
+            else:
+                resp_content = collections_resp.read()
+
+                # Verifies collection.xml files for presence of content
+                assert resp_content.count(b"<md:") >= 1 and resp_content.count(b"<col:content") >= 1

--- a/tests/s3_bucket/test_github_content_repos.py
+++ b/tests/s3_bucket/test_github_content_repos.py
@@ -3,10 +3,9 @@ import urllib
 import urllib.error
 import urllib.parse
 import urllib.request
-import requests
 
 """
-Verifies index.cnxml content of collection modules of every content repo in github.
+Verifies content of index.cnxml of every collection module of every github content repo.
 Latest update on March. 23nd, 2021
 """
 


### PR DESCRIPTION
Adding another testing for git content repos - to verify that collection.xml files are not empty

Also, I made 2 little changes to test_github_content_repos.py, which was approved in a previous PR 