### PR TITLE
amending qa redirect test to check for 200 and non-200 status codes for each page url variation

### DIFF
--- a/tests/webview/integration/test_rex_redirects5.py
+++ b/tests/webview/integration/test_rex_redirects5.py
@@ -1,0 +1,50 @@
+import backoff
+import requests
+
+from tests import markers
+
+import csv
+import pytest
+
+
+@backoff.on_exception(backoff.expo, requests.exceptions.ConnectionError)
+def get_url(url):
+    return requests.get(url)
+
+
+@markers.slow
+@markers.nondestructive
+def test_calculus2_uri_redirect_to_rex(webview_base_url, rex_base_url, calculus_vol_2_uri):
+    # GIVEN a webview_base_url, rex_base_url and a calculus_vol_2_uri
+
+    # WHEN we go to a page based on the webview_base_url and uri
+    cnx_page_slug = calculus_vol_2_uri.split("/")[-1]
+    cnx_url = f"{webview_base_url}{calculus_vol_2_uri}"
+    response = get_url(cnx_url)
+
+    status_codes = []
+    error_urls = []
+
+    # THEN we are redirected to rex
+    if response.status_code != 200:
+
+        status_codes.append(str(response.status_code))
+        error_urls.append(cnx_url)
+
+        dict_urls = {"PAGE URL": error_urls[i] for i in range(len(status_codes))}
+        dict_errors = {"ERROR": status_codes[i] for i in range(len(status_codes))}
+        dict_urls_errors = {**dict_urls, **dict_errors}
+
+        with open("url_error_list.csv", "a") as urlerr:
+            writer = csv.DictWriter(urlerr, dict_urls_errors.keys())
+
+            if urlerr.tell() == 0:
+                writer.writeheader()
+
+            writer.writerow(dict_urls_errors)
+
+        pytest.fail(f"{response.status_code} in {cnx_page_slug}")
+
+    else:
+        assert 200 == response.status_code
+        assert response.url.startswith(rex_base_url)

--- a/tests/webview/integration/test_rex_redirects5.py
+++ b/tests/webview/integration/test_rex_redirects5.py
@@ -22,18 +22,10 @@ def test_calculus2_uri_redirect_to_rex(webview_base_url, rex_base_url, calculus_
     cnx_url = f"{webview_base_url}{calculus_vol_2_uri}"
     response = get_url(cnx_url)
 
-    status_codes = []
-    error_urls = []
-
     # THEN we are redirected to rex
     if response.status_code != 200:
 
-        status_codes.append(str(response.status_code))
-        error_urls.append(cnx_url)
-
-        dict_urls = {"PAGE URL": error_urls[i] for i in range(len(status_codes))}
-        dict_errors = {"ERROR": status_codes[i] for i in range(len(status_codes))}
-        dict_urls_errors = {**dict_urls, **dict_errors}
+        dict_urls_errors = {"ERROR": response.status_code, "PAGE URL": cnx_url}
 
         with open("url_error_list.csv", "a") as urlerr:
             writer = csv.DictWriter(urlerr, dict_urls_errors.keys())
@@ -46,5 +38,4 @@ def test_calculus2_uri_redirect_to_rex(webview_base_url, rex_base_url, calculus_
         pytest.fail(f"{response.status_code} in {cnx_page_slug}")
 
     else:
-        assert 200 == response.status_code
         assert response.url.startswith(rex_base_url)

--- a/tests/webview/integration/test_rex_redirects5.py
+++ b/tests/webview/integration/test_rex_redirects5.py
@@ -12,6 +12,16 @@ def get_url(url):
     return requests.get(url)
 
 
+def log_failures_to_csv(status_code, cnx_url):
+    dict_urls_errors = {"ERROR": status_code, "PAGE URL": cnx_url}
+
+    with open("url_failures_report.csv", "a") as urlerr:
+        writer = csv.DictWriter(urlerr, dict_urls_errors.keys())
+        if urlerr.tell() == 0:
+            writer.writeheader()
+        writer.writerow(dict_urls_errors)
+
+
 @markers.slow
 @markers.nondestructive
 def test_calculus2_uri_redirect_to_rex(webview_base_url, rex_base_url, calculus_vol_2_uri):
@@ -24,16 +34,7 @@ def test_calculus2_uri_redirect_to_rex(webview_base_url, rex_base_url, calculus_
 
     # THEN we are redirected to rex
     if response.status_code != 200:
-
-        dict_urls_errors = {"ERROR": response.status_code, "PAGE URL": cnx_url}
-
-        with open("url_error_list.csv", "a") as urlerr:
-            writer = csv.DictWriter(urlerr, dict_urls_errors.keys())
-
-            if urlerr.tell() == 0:
-                writer.writeheader()
-
-            writer.writerow(dict_urls_errors)
+        log_failures_to_csv(response.status_code, cnx_url)
 
         pytest.fail(f"{response.status_code} in {cnx_page_slug}")
 


### PR DESCRIPTION
these are amendments to my redirect test in cnx-automation repo (test_rex_redirects.py) as per discussions from few weeks back. As per Phil's comments I removed checking page slugs and added checking for response.status_code. Anything different than 200 is then written out to a csv file which then can be checked by Neil and others to investigate while the book page fails. I assign this to @philschatz as per his explanation/advise and/or @rnathuji